### PR TITLE
M1: semantic X-rule public names + CLI exit-code taxonomy

### DIFF
--- a/reporting/docs/cli_exit_codes.md
+++ b/reporting/docs/cli_exit_codes.md
@@ -1,0 +1,90 @@
+# CLI exit codes
+
+The ``hai`` CLI exits with a small set of codes that classify failures
+by cause. An agent or shell caller can react programmatically without
+parsing stderr: retry on ``TRANSIENT``, surface ``NOT_FOUND`` to the
+user, stop and reconsider on ``USER_INPUT`` or ``INTERNAL``.
+
+The constants live in
+``src/health_agent_infra/core/exit_codes.py``. Import them rather than
+writing literal integers.
+
+## Codes
+
+| Code | Constant       | Meaning |
+|-----:|----------------|---------|
+| 0    | ``OK``         | Command completed as intended. |
+| 1    | ``USER_INPUT`` | The invocation was wrong: missing / conflicting flags, unreadable user-supplied JSON, missing credentials the caller was expected to provide, or a state precondition the caller controls (e.g. ``hai state init`` hasn't been run yet). |
+| 2    | ``TRANSIENT``  | An external dependency failed in a way a retry might fix: vendor 5xx, rate limit, network blip. |
+| 3    | ``NOT_FOUND``  | The target identifier is well-formed but the runtime has no record of it. Today the only producer is an unknown ``daily_plan_id`` passed to ``hai explain``. |
+| 4    | ``INTERNAL``   | A runtime invariant tripped that should not be reachable from normal inputs. Indicates a bug, not caller error. |
+
+## Why TRANSIENT stays at 2
+
+Before the taxonomy, every non-zero exit was ``2``. Callers that
+treated any non-zero code as "retry" worked fine for vendor blips and
+continued to work when we introduced distinct codes — because we kept
+``TRANSIENT`` at ``2`` and pushed user-input errors *down* to ``1``.
+Shifting ``TRANSIENT`` to a new code would have silently broken those
+retry loops without a clean signal to the caller. ``1`` was free, so
+``USER_INPUT`` got it.
+
+## Scope
+
+M1 migrated the five CLI handlers with the highest operational value
+(the pull → synthesize → explain path, plus credential setup). Every
+other handler still returns the legacy ``0 / 2``; those will migrate
+in follow-up PRs.
+
+| Handler | Migrated in M1? | Codes produced |
+|---|:---:|---|
+| ``hai pull``           | ✅ | ``OK``, ``USER_INPUT`` (no creds), ``TRANSIENT`` (adapter 5xx) |
+| ``hai auth garmin``    | ✅ | ``OK``, ``USER_INPUT`` |
+| ``hai auth status``    | ✅ | ``OK`` |
+| ``hai synthesize``     | ✅ | ``OK``, ``USER_INPUT``, ``INTERNAL`` (write-surface violation) |
+| ``hai explain``        | ✅ | ``OK``, ``USER_INPUT``, ``NOT_FOUND`` |
+| ``hai daily``          | ❌ | legacy ``0 / 2`` |
+| ``hai state *``        | ❌ | legacy ``0 / 2`` |
+| ``hai intake *``       | ❌ | legacy ``0 / 2`` |
+| ``hai review *``       | ❌ | legacy ``0 / 2`` |
+| ``hai memory *``       | ❌ | legacy ``0 / 2`` |
+| ``hai propose``        | ❌ | legacy ``0 / 2`` |
+| ``hai writeback``      | ❌ | legacy ``0 / 2`` |
+| ``hai clean``          | ❌ | legacy ``0 / 2`` |
+| ``hai doctor``         | ❌ | legacy ``0 / 2`` |
+
+## Usage — Python
+
+```python
+from health_agent_infra.core import exit_codes
+
+# Inside a subcommand:
+if not db_path.exists():
+    print("run `hai state init` first", file=sys.stderr)
+    return exit_codes.USER_INPUT
+```
+
+## Usage — shell
+
+```bash
+hai pull --live --date "$(date -I)"
+case $? in
+  0) echo "ok" ;;
+  1) echo "invocation error — fix flags and retry" ;;
+  2) echo "transient — back off and retry"; sleep 30; exec "$0" "$@" ;;
+  3) echo "target not found" ;;
+  4) echo "internal error — file a bug" ;;
+esac
+```
+
+## Stability contract
+
+- Numeric values of ``OK`` / ``USER_INPUT`` / ``TRANSIENT`` / ``NOT_FOUND`` /
+  ``INTERNAL`` are frozen. Changing one is a breaking change.
+- New codes may be added to the taxonomy; they will take the next free
+  integer.
+- A migrated handler may be narrowed (fewer codes produced) but never
+  broadened silently — if a handler starts producing a new code, this
+  doc's scope table is updated in the same PR.
+- A legacy handler (``❌`` above) makes no promise beyond "``0`` on
+  success, non-zero otherwise" until it migrates.

--- a/reporting/docs/x_rules.md
+++ b/reporting/docs/x_rules.md
@@ -20,26 +20,43 @@ All thresholds are read from ``~/.config/hai/thresholds.toml`` under
 the ``[synthesis.x_rules]`` section. Defaults live in
 ``core/config.py :: DEFAULT_THRESHOLDS``.
 
+## Rule naming
+
+Every rule has two names. The **internal id** (``X1a``, ``X3b``, ``X9``)
+is the stable handle — it appears in DB rows, JSONL audit records,
+eval-scenario fixtures, and the ``plan.x_rules_fired`` array. The
+**public name** is a readable slug that shows up in ``hai explain``
+output, agent-facing JSON (``firing["public_name"]``), and the tables
+below. Renaming an internal id would break audit continuity; the public
+name is free to evolve.
+
+The mapping lives in ``X_RULE_PUBLIC_NAMES`` in
+``src/health_agent_infra/core/synthesis_policy.py``. Adding a rule
+means appending a row there and adding the **Public name** column entry
+in the relevant table here so the two never drift apart. Slug pattern:
+``<trigger>-<tier_verb>-<target>`` — the tier verb mirrors the tier
+taxonomy (``softens`` / ``blocks`` / ``caps-confidence`` / ``bumps``).
+
 ## Phase A rules
 
-| ID | Trigger | Target | Tier | Mutation |
-|---|---|---|---|---|
-| X1a | ``sleep.classified_state.sleep_debt_band == moderate`` AND a hard proposal exists | each hard proposal's domain | soften | action → domain's ``downgrade_action`` |
-| X1b | ``sleep.classified_state.sleep_debt_band == elevated`` AND a hard proposal exists | each hard proposal's domain | block | action → domain's ``escalate_action`` |
-| X2 | ``nutrition.classified_state.calorie_deficit_kcal ≥ 500`` OR ``protein_ratio < 0.7`` AND a hard strength or recovery proposal exists | strength / recovery | soften | action → domain's ``downgrade_action`` |
-| X3a | ``1.3 ≤ recovery.today.acwr_ratio < 1.5`` AND a hard proposal exists | each hard proposal's domain | soften | action → domain's ``downgrade_action`` |
-| X3b | ``recovery.today.acwr_ratio ≥ 1.5`` AND a hard proposal exists | each hard proposal's domain | block | action → domain's ``escalate_action`` |
-| X4 | Yesterday's strength = heavy lower body AND running intervals/tempo proposed today | running | soften | action → ``downgrade_to_easy_aerobic`` |
-| X5 | Yesterday's running = long run or hard intervals AND lower-body strength proposed today | strength | soften | action → ``downgrade_to_technique_or_accessory`` |
-| X6a | ``stress.today_body_battery < 30`` AND a hard proposal exists | each hard proposal's domain | soften | action → domain's ``downgrade_action`` |
-| X6b | ``stress.today_body_battery < 15`` AND a hard proposal exists | each hard proposal's domain | block | action → domain's ``escalate_action`` |
-| X7 | ``stress.classified_state.garmin_stress_band ∈ {high, very_high}`` | every proposal's domain | cap_confidence | confidence → ``moderate`` (no action mutation) |
+| ID | Public name | Trigger | Target | Tier | Mutation |
+|---|---|---|---|---|---|
+| X1a | sleep-debt-softens-hard | ``sleep.classified_state.sleep_debt_band == moderate`` AND a hard proposal exists | each hard proposal's domain | soften | action → domain's ``downgrade_action`` |
+| X1b | sleep-debt-blocks-hard | ``sleep.classified_state.sleep_debt_band == elevated`` AND a hard proposal exists | each hard proposal's domain | block | action → domain's ``escalate_action`` |
+| X2 | underfuelling-softens-hard | ``nutrition.classified_state.calorie_deficit_kcal ≥ 500`` OR ``protein_ratio < 0.7`` AND a hard strength or recovery proposal exists | strength / recovery | soften | action → domain's ``downgrade_action`` |
+| X3a | load-spike-softens-hard | ``1.3 ≤ recovery.today.acwr_ratio < 1.5`` AND a hard proposal exists | each hard proposal's domain | soften | action → domain's ``downgrade_action`` |
+| X3b | load-spike-blocks-hard | ``recovery.today.acwr_ratio ≥ 1.5`` AND a hard proposal exists | each hard proposal's domain | block | action → domain's ``escalate_action`` |
+| X4 | lower-body-sequencing-softens-run | Yesterday's strength = heavy lower body AND running intervals/tempo proposed today | running | soften | action → ``downgrade_to_easy_aerobic`` |
+| X5 | endurance-fatigue-softens-strength | Yesterday's running = long run or hard intervals AND lower-body strength proposed today | strength | soften | action → ``downgrade_to_technique_or_accessory`` |
+| X6a | body-battery-low-softens-hard | ``stress.today_body_battery < 30`` AND a hard proposal exists | each hard proposal's domain | soften | action → domain's ``downgrade_action`` |
+| X6b | body-battery-depleted-blocks-hard | ``stress.today_body_battery < 15`` AND a hard proposal exists | each hard proposal's domain | block | action → domain's ``escalate_action`` |
+| X7 | stress-elevated-caps-confidence | ``stress.classified_state.garmin_stress_band ∈ {high, very_high}`` | every proposal's domain | cap_confidence | confidence → ``moderate`` (no action mutation) |
 
 ## Phase B rules
 
-| ID | Trigger | Target | Tier | Mutation |
-|---|---|---|---|---|
-| X9 | Any training-domain (recovery / running / strength) draft carries a hard baseline action AND a nutrition draft exists | nutrition | adjust | action_detail appended with protein-target multiplier + ``reason_token=x9_training_intensity_bump`` (action unchanged) |
+| ID | Public name | Trigger | Target | Tier | Mutation |
+|---|---|---|---|---|---|
+| X9 | training-intensity-bumps-protein | Any training-domain (recovery / running / strength) draft carries a hard baseline action AND a nutrition draft exists | nutrition | adjust | action_detail appended with protein-target multiplier + ``reason_token=x9_training_intensity_bump`` (action unchanged) |
 
 ## Tier precedence
 

--- a/safety/tests/test_cli_exit_codes.py
+++ b/safety/tests/test_cli_exit_codes.py
@@ -1,0 +1,281 @@
+"""Pin the CLI exit-code taxonomy for every migrated handler.
+
+Covers the five codes defined in
+``src/health_agent_infra/core/exit_codes.py`` and the handlers migrated
+in M1: ``hai pull``, ``hai auth garmin``, ``hai auth status``,
+``hai synthesize``, ``hai explain``. Every non-migrated handler is
+intentionally absent — their rc contract remains the pre-M1 mix until
+a follow-up PR migrates them.
+
+Tests here assert *only* on return codes. They are paired with the
+domain-specific suites (``test_cli_explain.py``, ``test_cli_synthesize.py``,
+``test_cli_pull_live_and_auth.py``) which continue to assert on
+stdout / stderr payloads.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from health_agent_infra import cli as cli_mod
+from health_agent_infra.cli import main as cli_main
+from health_agent_infra.core import exit_codes
+from health_agent_infra.core.pull.auth import CredentialStore
+from health_agent_infra.core.pull.garmin_live import GarminLiveError
+
+
+# ---------------------------------------------------------------------------
+# Constants contract
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_values_are_stable():
+    """Numeric values are a public contract — any change breaks callers."""
+
+    assert exit_codes.OK == 0
+    assert exit_codes.USER_INPUT == 1
+    assert exit_codes.TRANSIENT == 2
+    assert exit_codes.NOT_FOUND == 3
+    assert exit_codes.INTERNAL == 4
+
+
+def test_exit_code_values_are_unique():
+    values = [
+        exit_codes.OK,
+        exit_codes.USER_INPUT,
+        exit_codes.TRANSIENT,
+        exit_codes.NOT_FOUND,
+        exit_codes.INTERNAL,
+    ]
+    assert len(values) == len(set(values))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeKeyring:
+    def __init__(self):
+        self._data: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service, username):
+        return self._data.get((service, username))
+
+    def set_password(self, service, username, password):
+        self._data[(service, username)] = password
+
+    def delete_password(self, service, username):
+        self._data.pop((service, username), None)
+
+
+def _fake_store(env=None) -> CredentialStore:
+    return CredentialStore(backend=_FakeKeyring(), env=env or {})
+
+
+def _init_state_db(tmp_path: Path) -> Path:
+    """Invoke ``hai state init`` via ``cli_main`` to stand up a fresh DB."""
+
+    db_path = tmp_path / "state.db"
+    rc = cli_main(["state", "init", "--db-path", str(db_path)])
+    assert rc == exit_codes.OK
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# hai explain
+# ---------------------------------------------------------------------------
+
+
+def test_explain_conflicting_selectors_returns_user_input(tmp_path, capsys):
+    db_path = _init_state_db(tmp_path)
+    capsys.readouterr()  # discard state-init stdout
+
+    rc = cli_main([
+        "explain",
+        "--daily-plan-id", "plan_whatever",
+        "--for-date", "2026-04-17",
+        "--user-id", "u_local_1",
+        "--db-path", str(db_path),
+    ])
+    assert rc == exit_codes.USER_INPUT
+
+
+def test_explain_no_selectors_returns_user_input(tmp_path, capsys):
+    db_path = _init_state_db(tmp_path)
+    capsys.readouterr()
+
+    rc = cli_main(["explain", "--db-path", str(db_path)])
+    assert rc == exit_codes.USER_INPUT
+
+
+def test_explain_missing_db_returns_user_input(tmp_path, capsys):
+    missing = tmp_path / "does_not_exist.db"
+    rc = cli_main([
+        "explain",
+        "--daily-plan-id", "plan_whatever",
+        "--db-path", str(missing),
+    ])
+    assert rc == exit_codes.USER_INPUT
+
+
+def test_explain_unknown_plan_id_returns_not_found(tmp_path, capsys):
+    db_path = _init_state_db(tmp_path)
+    capsys.readouterr()
+
+    rc = cli_main([
+        "explain",
+        "--daily-plan-id", "plan_2099-01-01_ghost",
+        "--db-path", str(db_path),
+    ])
+    assert rc == exit_codes.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# hai synthesize
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_missing_db_returns_user_input(tmp_path, capsys):
+    missing = tmp_path / "nope.db"
+    rc = cli_main([
+        "synthesize",
+        "--as-of", "2026-04-17",
+        "--user-id", "u_local_1",
+        "--db-path", str(missing),
+    ])
+    assert rc == exit_codes.USER_INPUT
+
+
+def test_synthesize_bundle_only_and_drafts_conflict_returns_user_input(
+    tmp_path, capsys,
+):
+    db_path = _init_state_db(tmp_path)
+    capsys.readouterr()
+    drafts = tmp_path / "drafts.json"
+    drafts.write_text("[]", encoding="utf-8")
+
+    rc = cli_main([
+        "synthesize",
+        "--as-of", "2026-04-17",
+        "--user-id", "u_local_1",
+        "--db-path", str(db_path),
+        "--bundle-only",
+        "--drafts-json", str(drafts),
+    ])
+    assert rc == exit_codes.USER_INPUT
+
+
+def test_synthesize_unreadable_drafts_returns_user_input(tmp_path, capsys):
+    db_path = _init_state_db(tmp_path)
+    capsys.readouterr()
+    missing_drafts = tmp_path / "not_there.json"
+
+    rc = cli_main([
+        "synthesize",
+        "--as-of", "2026-04-17",
+        "--user-id", "u_local_1",
+        "--db-path", str(db_path),
+        "--drafts-json", str(missing_drafts),
+    ])
+    assert rc == exit_codes.USER_INPUT
+
+
+def test_synthesize_non_array_drafts_returns_user_input(tmp_path, capsys):
+    db_path = _init_state_db(tmp_path)
+    capsys.readouterr()
+    drafts = tmp_path / "bad_drafts.json"
+    drafts.write_text('{"not": "an array"}', encoding="utf-8")
+
+    rc = cli_main([
+        "synthesize",
+        "--as-of", "2026-04-17",
+        "--user-id", "u_local_1",
+        "--db-path", str(db_path),
+        "--drafts-json", str(drafts),
+    ])
+    assert rc == exit_codes.USER_INPUT
+
+
+# ---------------------------------------------------------------------------
+# hai pull --live
+# ---------------------------------------------------------------------------
+
+
+def test_pull_live_missing_credentials_returns_user_input(monkeypatch):
+    store = _fake_store()
+    monkeypatch.setattr(
+        cli_mod.CredentialStore,
+        "default",
+        classmethod(lambda cls: store),
+    )
+
+    rc = cli_main(["pull", "--live", "--date", "2026-04-17"])
+    assert rc == exit_codes.USER_INPUT
+
+
+def test_pull_live_adapter_error_returns_transient(monkeypatch):
+    store = _fake_store()
+    store.store_garmin("alice@example.com", "s3cret")
+    monkeypatch.setattr(
+        cli_mod.CredentialStore,
+        "default",
+        classmethod(lambda cls: store),
+    )
+
+    class _ExplodingAdapter:
+        source_name = "garmin_live"
+
+        def load(self, as_of):
+            raise GarminLiveError("vendor 503 — try again later")
+
+    monkeypatch.setattr(
+        cli_mod, "_build_live_adapter", lambda args: _ExplodingAdapter(),
+    )
+
+    rc = cli_main(["pull", "--live", "--date", "2026-04-17"])
+    assert rc == exit_codes.TRANSIENT
+
+
+# ---------------------------------------------------------------------------
+# hai auth garmin
+# ---------------------------------------------------------------------------
+
+
+def test_auth_garmin_missing_env_var_returns_user_input(monkeypatch):
+    store = _fake_store()
+    monkeypatch.setattr(
+        cli_mod.CredentialStore,
+        "default",
+        classmethod(lambda cls: store),
+    )
+    monkeypatch.delenv("HAI_EXIT_CODE_TEST_PW", raising=False)
+
+    rc = cli_main([
+        "auth", "garmin",
+        "--email", "alice@example.com",
+        "--password-env", "HAI_EXIT_CODE_TEST_PW",
+    ])
+    assert rc == exit_codes.USER_INPUT
+
+
+def test_auth_garmin_empty_stdin_password_returns_user_input(monkeypatch):
+    store = _fake_store()
+    monkeypatch.setattr(
+        cli_mod.CredentialStore,
+        "default",
+        classmethod(lambda cls: store),
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO("\n"))
+
+    rc = cli_main([
+        "auth", "garmin",
+        "--email", "alice@example.com",
+        "--password-stdin",
+    ])
+    assert rc == exit_codes.USER_INPUT

--- a/safety/tests/test_cli_explain.py
+++ b/safety/tests/test_cli_explain.py
@@ -27,6 +27,7 @@ from typing import Any
 
 import pytest
 
+from health_agent_infra.core import exit_codes
 from health_agent_infra.core.schemas import (
     ReviewEvent,
     ReviewOutcome,
@@ -419,7 +420,7 @@ def test_explain_supersession_linkage_walks_both_directions(tmp_path, capsys):
 
 
 def test_explain_rejects_when_plan_id_missing(tmp_path, capsys):
-    """An unknown plan id reports a not-found error and exits 2."""
+    """An unknown plan id reports a not-found error and exits NOT_FOUND."""
 
     from health_agent_infra.cli import main as cli_main
 
@@ -430,7 +431,7 @@ def test_explain_rejects_when_plan_id_missing(tmp_path, capsys):
         "--daily-plan-id", "plan_2099-01-01_nope",
         "--db-path", str(db_path),
     ])
-    assert rc == 2
+    assert rc == exit_codes.NOT_FOUND
     err = capsys.readouterr().err
     assert "no daily_plan row" in err
 
@@ -450,7 +451,7 @@ def test_explain_rejects_conflicting_flags(tmp_path, capsys):
         "--user-id", "u_local_1",
         "--db-path", str(db_path),
     ])
-    assert rc == 2
+    assert rc == exit_codes.USER_INPUT
     err = capsys.readouterr().err
     assert "either --daily-plan-id" in err.lower() or "not both" in err.lower()
 
@@ -466,6 +467,6 @@ def test_explain_rejects_when_no_selectors(tmp_path, capsys):
         "explain",
         "--db-path", str(db_path),
     ])
-    assert rc == 2
+    assert rc == exit_codes.USER_INPUT
     err = capsys.readouterr().err
     assert "provide --daily-plan-id" in err or "for-date" in err

--- a/safety/tests/test_cli_pull_live_and_auth.py
+++ b/safety/tests/test_cli_pull_live_and_auth.py
@@ -27,6 +27,7 @@ import pytest
 
 from health_agent_infra import cli as cli_mod
 from health_agent_infra.cli import main as cli_main
+from health_agent_infra.core import exit_codes
 from health_agent_infra.core.pull.auth import (
     EMAIL_ENV_VAR,
     PASSWORD_ENV_VAR,
@@ -101,7 +102,7 @@ def test_auth_garmin_fails_cleanly_when_password_env_missing(monkeypatch, capsys
         "auth", "garmin", "--email", "alice@example.com",
         "--password-env", "MY_PW_VAR_X",
     ])
-    assert rc == 2
+    assert rc == exit_codes.USER_INPUT
     err = capsys.readouterr().err
     assert "MY_PW_VAR_X" in err
 
@@ -112,7 +113,7 @@ def test_auth_garmin_rejects_empty_password(monkeypatch, capsys):
     monkeypatch.setattr(sys, "stdin", io.StringIO("\n"))
 
     rc = cli_main(["auth", "garmin", "--email", "alice@example.com", "--password-stdin"])
-    assert rc == 2
+    assert rc == exit_codes.USER_INPUT
     err = capsys.readouterr().err
     assert "password" in err
     assert store.load_garmin() is None
@@ -170,7 +171,7 @@ def test_pull_live_fails_cleanly_without_credentials(monkeypatch, capsys):
     monkeypatch.setattr(cli_mod.CredentialStore, "default", classmethod(lambda cls: store))
 
     rc = cli_main(["pull", "--live", "--date", "2026-04-17"])
-    assert rc == 2
+    assert rc == exit_codes.USER_INPUT
     err = capsys.readouterr().err
     assert "credentials" in err.lower()
 
@@ -243,7 +244,7 @@ def test_pull_live_wraps_adapter_error(monkeypatch, capsys):
     monkeypatch.setattr(cli_mod, "_build_live_adapter", lambda args: ExplodingAdapter())
 
     rc = cli_main(["pull", "--live", "--date", "2026-04-17"])
-    assert rc == 2
+    assert rc == exit_codes.TRANSIENT
     err = capsys.readouterr().err
     assert "upstream 500" in err
 

--- a/safety/tests/test_cli_synthesize.py
+++ b/safety/tests/test_cli_synthesize.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 import pytest
 
+from health_agent_infra.core import exit_codes
 from health_agent_infra.core.schemas import canonical_daily_plan_id
 from health_agent_infra.core.state import (
     initialize_database,
@@ -1119,6 +1120,6 @@ def test_cli_synthesize_bundle_only_rejects_conflicting_flags(
         "--bundle-only",
         "--drafts-json", str(drafts_path),
     ])
-    assert rc == 2
+    assert rc == exit_codes.USER_INPUT
     err = capsys.readouterr().err
     assert "bundle-only" in err.lower()

--- a/safety/tests/test_synthesis_public_names.py
+++ b/safety/tests/test_synthesis_public_names.py
@@ -1,0 +1,110 @@
+"""Registry tests for X-rule public names.
+
+These pin the contract between ``X_RULE_PUBLIC_NAMES`` in
+``core/synthesis_policy.py`` and the evaluator tuples (``PHASE_A_EVALUATORS``
+/ ``PHASE_B_EVALUATORS``) so a new rule with no public name fails the
+suite at add time rather than silently rendering as an internal id.
+
+Coverage check derives expected ids from function names
+(``evaluate_x1a → X1a`` / ``evaluate_x3b → X3b`` / ``evaluate_x9 → X9``)
+which matches how the rule evaluators populate ``XRuleFiring.rule_id``.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from health_agent_infra.core.synthesis_policy import (
+    PHASE_A_EVALUATORS,
+    PHASE_B_EVALUATORS,
+    XRuleFiring,
+    X_RULE_PUBLIC_NAMES,
+    public_name_for,
+)
+
+
+def _expected_rule_ids() -> list[str]:
+    """Derive the expected rule-id set from the evaluator tuples.
+
+    ``evaluate_x3b`` → ``X3b`` (case-preserving via the internal id
+    convention: first letter uppercase, suffix lowercase).
+    """
+
+    ids: list[str] = []
+    for fn in PHASE_A_EVALUATORS + PHASE_B_EVALUATORS:
+        suffix = fn.__name__[len("evaluate_"):]
+        # "x1a" → "X1a", "x3b" → "X3b", "x9" → "X9".
+        ids.append(suffix[0].upper() + suffix[1:])
+    return ids
+
+
+def test_every_evaluator_has_a_registry_entry():
+    """Every rule the runtime can emit must have a public name.
+
+    Pinning this stops us from merging a new evaluator without
+    adding a row to ``X_RULE_PUBLIC_NAMES`` and the x_rules.md table.
+    """
+
+    expected = set(_expected_rule_ids())
+    missing = expected - set(X_RULE_PUBLIC_NAMES)
+    assert not missing, (
+        f"X-rule evaluators with no public name registered: {sorted(missing)}"
+    )
+
+
+def test_public_names_are_unique():
+    """Two rules cannot share a public name — collisions would make the
+    slug useless as a handle."""
+
+    names = list(X_RULE_PUBLIC_NAMES.values())
+    assert len(names) == len(set(names)), (
+        f"duplicate public name in X_RULE_PUBLIC_NAMES: {names}"
+    )
+
+
+_SLUG_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+
+
+@pytest.mark.parametrize(
+    "rule_id,public_name",
+    sorted(X_RULE_PUBLIC_NAMES.items()),
+)
+def test_public_name_is_a_valid_slug(rule_id, public_name):
+    assert _SLUG_RE.match(public_name), (
+        f"public name for {rule_id!r} is not a valid kebab slug: "
+        f"{public_name!r}"
+    )
+
+
+def test_spot_checks():
+    assert public_name_for("X1a") == "sleep-debt-softens-hard"
+    assert public_name_for("X9") == "training-intensity-bumps-protein"
+
+
+def test_unknown_rule_ids_return_none():
+    assert public_name_for("X999_future") is None
+    assert public_name_for("") is None
+
+
+def _make_firing(rule_id: str) -> XRuleFiring:
+    return XRuleFiring(
+        rule_id=rule_id,
+        tier="soften",
+        affected_domain="recovery",
+        trigger_note="synthetic",
+        recommended_mutation=None,
+        source_signals={},
+        phase="A",
+    )
+
+
+def test_to_dict_carries_public_name_for_registered_rule():
+    firing = _make_firing("X1a")
+    assert firing.to_dict()["public_name"] == "sleep-debt-softens-hard"
+
+
+def test_to_dict_carries_none_for_experimental_rule():
+    firing = _make_firing("X_experimental")
+    assert firing.to_dict()["public_name"] is None

--- a/src/health_agent_infra/cli.py
+++ b/src/health_agent_infra/cli.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from health_agent_infra import __version__ as _PACKAGE_VERSION
+from health_agent_infra.core import exit_codes
 from health_agent_infra.core.clean import build_raw_summary, clean_inputs
 from health_agent_infra.core.config import (
     ConfigError,
@@ -124,16 +125,20 @@ def cmd_pull(args: argparse.Namespace) -> int:
         try:
             adapter = _build_live_adapter(args)
         except GarminLiveError as exc:
+            # Credential-resolution failure — the caller controls this
+            # (run `hai auth garmin` or set env vars), so it's USER_INPUT
+            # rather than a transient vendor issue.
             print(f"live pull error: {exc}", file=sys.stderr)
-            return 2
+            return exit_codes.USER_INPUT
     else:
         adapter = GarminRecoveryReadinessAdapter()
 
     try:
         pull = adapter.load(as_of)
     except GarminLiveError as exc:
+        # Vendor API blip (5xx, rate limit, network) — a retry may fix it.
         print(f"live pull error: {exc}", file=sys.stderr)
-        return 2
+        return exit_codes.TRANSIENT
 
     manual = None
     if args.manual_readiness_json:
@@ -149,7 +154,7 @@ def cmd_pull(args: argparse.Namespace) -> int:
         "manual_readiness": manual,
     }
     _emit_json(payload)
-    return 0
+    return exit_codes.OK
 
 
 def _build_live_adapter(args: argparse.Namespace):
@@ -432,37 +437,37 @@ def cmd_auth_garmin(args: argparse.Namespace) -> int:
                 f"auth error: env var {args.password_env} is not set or empty",
                 file=sys.stderr,
             )
-            return 2
+            return exit_codes.USER_INPUT
 
     if email is None:
         try:
             email = input("Garmin email: ").strip()
         except EOFError:
             print("auth error: no email provided", file=sys.stderr)
-            return 2
+            return exit_codes.USER_INPUT
     if not email:
         print("auth error: email must be non-empty", file=sys.stderr)
-        return 2
+        return exit_codes.USER_INPUT
 
     if password is None:
         try:
             password = getpass.getpass("Garmin password: ")
         except EOFError:
             print("auth error: no password provided", file=sys.stderr)
-            return 2
+            return exit_codes.USER_INPUT
     if not password:
         print("auth error: password must be non-empty", file=sys.stderr)
-        return 2
+        return exit_codes.USER_INPUT
 
     store = _credential_store_for(args)
     try:
         store.store_garmin(email, password)
     except KeyringUnavailableError as exc:
         print(f"auth error: {exc}", file=sys.stderr)
-        return 2
+        return exit_codes.USER_INPUT
     except ValueError as exc:
         print(f"auth error: {exc}", file=sys.stderr)
-        return 2
+        return exit_codes.USER_INPUT
 
     # Emit a non-secret confirmation. Email presence is fine to surface so
     # the operator sees which account was stored; password is never shown.
@@ -472,7 +477,7 @@ def cmd_auth_garmin(args: argparse.Namespace) -> int:
         "email": email,
         "backend": _backend_kind(store),
     })
-    return 0
+    return exit_codes.OK
 
 
 def cmd_auth_status(args: argparse.Namespace) -> int:
@@ -482,7 +487,7 @@ def cmd_auth_status(args: argparse.Namespace) -> int:
     status = store.garmin_status()
     status["backend"] = _backend_kind(store)
     _emit_json(status)
-    return 0
+    return exit_codes.OK
 
 
 def _credential_store_for(args: argparse.Namespace) -> CredentialStore:
@@ -590,7 +595,7 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
             f"{db_path}. Run `hai state init` first.",
             file=sys.stderr,
         )
-        return 2
+        return exit_codes.USER_INPUT
 
     # --bundle-only is the skill seam: read-only emission of
     # (snapshot, proposals, phase_a_firings) so the daily-plan-synthesis
@@ -603,7 +608,7 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
                 "cannot be combined with --drafts-json or --supersede.",
                 file=sys.stderr,
             )
-            return 2
+            return exit_codes.USER_INPUT
         conn = open_connection(db_path)
         try:
             bundle = build_synthesis_bundle(
@@ -612,7 +617,7 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
         finally:
             conn.close()
         _emit_json(bundle)
-        return 0
+        return exit_codes.OK
 
     skill_drafts: Optional[list[dict]] = None
     if args.drafts_json:
@@ -626,14 +631,14 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
                 f"({args.drafts_json}): {exc}",
                 file=sys.stderr,
             )
-            return 2
+            return exit_codes.USER_INPUT
         if not isinstance(skill_drafts, list):
             print(
                 f"hai synthesize rejected: drafts JSON must be a JSON array; "
                 f"got {type(skill_drafts).__name__}",
                 file=sys.stderr,
             )
-            return 2
+            return exit_codes.USER_INPUT
 
     conn = open_connection(db_path)
     try:
@@ -647,18 +652,21 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
         )
     except SynthesisError as exc:
         print(f"hai synthesize rejected: {exc}", file=sys.stderr)
-        return 2
+        return exit_codes.USER_INPUT
     except XRuleWriteSurfaceViolation as exc:
+        # A write-surface violation means a Phase B rule tried to touch a
+        # field the guard disallows — a bug in the rule implementation,
+        # not anything the caller did. INTERNAL, not USER_INPUT.
         print(
             f"hai synthesize rejected: write_surface_violation: {exc}",
             file=sys.stderr,
         )
-        return 2
+        return exit_codes.INTERNAL
     finally:
         conn.close()
 
     _emit_json(result.to_dict())
-    return 0
+    return exit_codes.OK
 
 
 # ---------------------------------------------------------------------------
@@ -697,14 +705,14 @@ def cmd_explain(args: argparse.Namespace) -> int:
             "(--for-date and --user-id), not both.",
             file=sys.stderr,
         )
-        return 2
+        return exit_codes.USER_INPUT
     if not args.daily_plan_id and not (args.for_date and args.user_id):
         print(
             "hai explain rejected: provide --daily-plan-id, or both "
             "--for-date and --user-id.",
             file=sys.stderr,
         )
-        return 2
+        return exit_codes.USER_INPUT
 
     db_path = resolve_db_path(args.db_path)
     if not db_path.exists():
@@ -713,7 +721,7 @@ def cmd_explain(args: argparse.Namespace) -> int:
             f"{db_path}. Run `hai state init` first.",
             file=sys.stderr,
         )
-        return 2
+        return exit_codes.USER_INPUT
 
     conn = open_connection(db_path)
     try:
@@ -729,8 +737,9 @@ def cmd_explain(args: argparse.Namespace) -> int:
                     user_id=args.user_id,
                 )
         except ExplainNotFoundError as exc:
+            # Well-formed request, no matching row — NOT_FOUND, not user-input.
             print(f"hai explain: {exc}", file=sys.stderr)
-            return 2
+            return exit_codes.NOT_FOUND
     finally:
         conn.close()
 
@@ -738,7 +747,7 @@ def cmd_explain(args: argparse.Namespace) -> int:
         sys.stdout.write(render_bundle_text(bundle))
     else:
         _emit_json(bundle_to_dict(bundle))
-    return 0
+    return exit_codes.OK
 
 
 # ---------------------------------------------------------------------------

--- a/src/health_agent_infra/core/exit_codes.py
+++ b/src/health_agent_infra/core/exit_codes.py
@@ -1,0 +1,43 @@
+"""CLI exit-code taxonomy.
+
+A small, frozen classification so agents and shell callers can react to
+non-zero exits programmatically without parsing stderr.
+
+Five codes. They cover the four failure classes the CLI actually
+distinguishes plus the success case:
+
+- ``OK`` (0) — the command completed as intended.
+- ``USER_INPUT`` (1) — the invocation itself was wrong: missing or
+  conflicting flags, unreadable user-supplied JSON, missing credentials
+  the caller was expected to provide, or a state precondition the caller
+  controls (``hai state init`` hasn't been run yet).
+- ``TRANSIENT`` (2) — an external dependency failed in a way a retry
+  might fix: a vendor 5xx, a rate limit, a network blip. The caller can
+  back off and try again.
+- ``NOT_FOUND`` (3) — the target identifier is well-formed but the
+  runtime has no record of it. Most often: an unknown ``daily_plan_id``.
+- ``INTERNAL`` (4) — a runtime invariant tripped that should not be
+  reachable from normal inputs (e.g. a Phase B rule with a missing
+  target registry entry). Indicates a bug, not a caller error.
+
+TRANSIENT keeps its historical value of ``2`` deliberately. Every prior
+caller that treated "non-zero" as "retry" kept working when we moved
+user-input errors down to ``1`` and transient errors stayed at ``2``;
+shifting TRANSIENT would have broken those retry loops.
+
+Migration scope is documented in
+``reporting/docs/cli_exit_codes.md`` — only a handful of handlers are
+on the taxonomy as of M1; the rest still return the legacy mix of ``0``
+and ``2`` until their follow-up PRs land.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+OK: Final[int] = 0
+USER_INPUT: Final[int] = 1
+TRANSIENT: Final[int] = 2
+NOT_FOUND: Final[int] = 3
+INTERNAL: Final[int] = 4

--- a/src/health_agent_infra/core/explain/queries.py
+++ b/src/health_agent_infra/core/explain/queries.py
@@ -30,6 +30,7 @@ from datetime import date
 from typing import Any, Optional
 
 from health_agent_infra.core.schemas import canonical_daily_plan_id
+from health_agent_infra.core.synthesis_policy import public_name_for
 
 
 class ExplainNotFoundError(LookupError):
@@ -70,6 +71,7 @@ class ExplainXRuleFiring:
     source_signals: dict[str, Any]
     orphan: bool
     fired_at: str
+    public_name: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -317,6 +319,7 @@ def _load_firings_for_plan(
             source_signals=_loads(row["source_signals_json"]) or {},
             orphan=bool(row["orphan"]),
             fired_at=row["fired_at"],
+            public_name=public_name_for(row["x_rule_id"]),
         )
         if firing.tier in _PHASE_B_TIERS:
             phase_b.append(firing)

--- a/src/health_agent_infra/core/explain/render.py
+++ b/src/health_agent_infra/core/explain/render.py
@@ -198,9 +198,15 @@ def _format_proposal(p: ExplainProposal) -> str:
 
 
 def _format_firing(f: ExplainXRuleFiring) -> str:
+    header = (
+        f"- {f.rule_id} [{f.public_name}] ({f.tier}) → {f.affected_domain}"
+        if f.public_name
+        else f"- {f.rule_id} ({f.tier}) → {f.affected_domain}"
+    )
+    if f.orphan:
+        header += "  [orphan]"
     parts = [
-        f"- {f.rule_id} ({f.tier}) → {f.affected_domain}"
-        + ("  [orphan]" if f.orphan else ""),
+        header,
         f"    trigger    : {f.trigger_note}",
     ]
     if f.mutation not in (None, {}, []):

--- a/src/health_agent_infra/core/research/sources.py
+++ b/src/health_agent_infra/core/research/sources.py
@@ -89,7 +89,8 @@ SOURCES: tuple[Source, ...] = (
         source_class="internal_x_rules",
         origin_path="reporting/docs/x_rules.md",
         excerpt=(
-            "X1a | ``sleep.classified_state.sleep_debt_band == moderate``"
+            "X1a | sleep-debt-softens-hard | "
+            "``sleep.classified_state.sleep_debt_band == moderate``"
         ),
         topics=("sleep_debt",),
     ),
@@ -99,7 +100,8 @@ SOURCES: tuple[Source, ...] = (
         source_class="internal_x_rules",
         origin_path="reporting/docs/x_rules.md",
         excerpt=(
-            "X1b | ``sleep.classified_state.sleep_debt_band == elevated``"
+            "X1b | sleep-debt-blocks-hard | "
+            "``sleep.classified_state.sleep_debt_band == elevated``"
         ),
         topics=("sleep_debt",),
     ),
@@ -109,7 +111,8 @@ SOURCES: tuple[Source, ...] = (
         source_class="internal_x_rules",
         origin_path="reporting/docs/x_rules.md",
         excerpt=(
-            "X2 | ``nutrition.classified_state.calorie_deficit_kcal ≥ 500``"
+            "X2 | underfuelling-softens-hard | "
+            "``nutrition.classified_state.calorie_deficit_kcal ≥ 500``"
             " OR ``protein_ratio < 0.7``"
         ),
         topics=("protein_ratio_strength",),
@@ -131,7 +134,8 @@ SOURCES: tuple[Source, ...] = (
         source_class="internal_x_rules",
         origin_path="reporting/docs/x_rules.md",
         excerpt=(
-            "X6a | ``stress.today_body_battery < 30``"
+            "X6a | body-battery-low-softens-hard | "
+            "``stress.today_body_battery < 30``"
         ),
         topics=("body_battery",),
     ),

--- a/src/health_agent_infra/core/synthesis_policy.py
+++ b/src/health_agent_infra/core/synthesis_policy.py
@@ -95,6 +95,44 @@ PHASE_B_TARGETS: dict[str, frozenset[str]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Semantic public names for each X-rule. The internal IDs (``X1a``, ``X3b``,
+# …) stay the stable handle across logs, DB rows, and scenario fixtures — a
+# public name is a readability aid layered on top, surfaced in
+# :meth:`XRuleFiring.to_dict`, the explain bundle, and the docs tables.
+#
+# Naming pattern: ``<trigger>-<tier_verb>-<target>``. Tier verbs follow the
+# tier taxonomy — ``softens`` / ``blocks`` / ``caps-confidence`` / ``bumps``.
+# Registering a new rule means appending a row here *and* adding the column
+# to the Phase A / Phase B tables in ``reporting/docs/x_rules.md`` so the
+# internal id and public name never diverge between code and docs.
+# ---------------------------------------------------------------------------
+X_RULE_PUBLIC_NAMES: dict[str, str] = {
+    "X1a": "sleep-debt-softens-hard",
+    "X1b": "sleep-debt-blocks-hard",
+    "X2": "underfuelling-softens-hard",
+    "X3a": "load-spike-softens-hard",
+    "X3b": "load-spike-blocks-hard",
+    "X4": "lower-body-sequencing-softens-run",
+    "X5": "endurance-fatigue-softens-strength",
+    "X6a": "body-battery-low-softens-hard",
+    "X6b": "body-battery-depleted-blocks-hard",
+    "X7": "stress-elevated-caps-confidence",
+    "X9": "training-intensity-bumps-protein",
+}
+
+
+def public_name_for(rule_id: str) -> Optional[str]:
+    """Return the human-readable public name for ``rule_id``, or ``None``.
+
+    Unknown / experimental rule ids deliberately return ``None`` rather
+    than raising, so historical DB rows written before a rename land
+    cleanly — callers render them under their internal id alone.
+    """
+
+    return X_RULE_PUBLIC_NAMES.get(rule_id)
+
+
 @dataclass(frozen=True)
 class XRuleFiring:
     """One deterministic firing of a cross-domain X-rule.
@@ -129,6 +167,7 @@ class XRuleFiring:
     def to_dict(self) -> dict[str, Any]:
         return {
             "rule_id": self.rule_id,
+            "public_name": public_name_for(self.rule_id),
             "tier": self.tier,
             "affected_domain": self.affected_domain,
             "trigger_note": self.trigger_note,


### PR DESCRIPTION
## Summary
- Adds `X_RULE_PUBLIC_NAMES` registry + `public_name_for()` in `core/synthesis_policy.py`; public names surface in `XRuleFiring.to_dict()`, `ExplainXRuleFiring`, and `hai explain --text` firing headers (e.g. `- X1a [sleep-debt-softens-hard] (soften) → recovery`). Internal IDs stay the stable audit handle.
- Adds `core/exit_codes.py` with five `Final[int]` constants (`OK=0`, `USER_INPUT=1`, `TRANSIENT=2`, `NOT_FOUND=3`, `INTERNAL=4`). `TRANSIENT` keeps value `2` so existing "retry on non-zero" callers stay correct.
- Migrates 5 high-value CLI handlers (`cmd_pull`, `cmd_auth_garmin`, `cmd_auth_status`, `cmd_synthesize`, `cmd_explain`) to the taxonomy. Other handlers stay on legacy `0/2` until follow-up PRs.
- New docs: `reporting/docs/cli_exit_codes.md` (codes, scope, stability contract). Existing `x_rules.md` gains a "Rule naming" subsection and Public-name column.

## Test plan
- [x] `uv run pytest safety/tests -q` — 1342 passing locally
- [x] Smoke: `hai explain --text` shows `[public-name]` on firing headers
- [x] Smoke: `hai explain --daily-plan-id <unknown>` exits 3; missing selectors exits 1