### PR TITLE
M2: sync_run_log for per-source freshness observability

### DIFF
--- a/safety/tests/test_state_read_snapshot.py
+++ b/safety/tests/test_state_read_snapshot.py
@@ -482,9 +482,65 @@ def test_snapshot_envelope_has_expected_top_level_keys(tmp_path: Path):
         "schema_version", "as_of_date", "user_id", "lookback_days",
         "history_range", "recovery", "running", "gym", "nutrition",
         "stress", "notes", "goals_active", "recommendations", "reviews",
+        "sources",
     }
     assert expected.issubset(snap.keys())
     assert snap["schema_version"] == "state_snapshot.v1"
+    # Freshness block is present-but-empty on a DB with no sync rows.
+    assert snap["sources"] == {}
+
+
+def test_snapshot_sources_block_carries_freshness_per_source(tmp_path: Path):
+    """Seed sync_run_log rows for two sources; the sources block should
+    surface the newest successful row per source plus staleness hours
+    against as_of_date's end-of-day anchor."""
+
+    db = _init_db(tmp_path)
+    conn = open_connection(db)
+    try:
+        # garmin last synced at 06:00 UTC on 2026-04-17; staleness
+        # against end of 2026-04-17 (00:00 UTC 2026-04-18) = 18 hours.
+        # nutrition_manual at 20:00 UTC on 2026-04-17 = 4 hours stale.
+        # An older 'ok' garmin sync and an intervening 'failed' one
+        # must not surface — the reader picks the newest 'ok' only.
+        conn.executemany(
+            "INSERT INTO sync_run_log "
+            "(source, user_id, mode, started_at, completed_at, status, "
+            " rows_pulled, rows_accepted, duplicates_skipped) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("garmin", USER, "csv",
+                 "2026-04-16T06:00:00+00:00", "2026-04-16T06:00:05+00:00",
+                 "ok", 1, 1, 0),
+                ("garmin", USER, "csv",
+                 "2026-04-17T06:00:00+00:00", "2026-04-17T06:00:00+00:00",
+                 "ok", 1, 1, 0),
+                ("garmin", USER, "csv",
+                 "2026-04-17T08:00:00+00:00", "2026-04-17T08:00:01+00:00",
+                 "failed", None, None, None),
+                ("nutrition_manual", USER, "manual",
+                 "2026-04-17T20:00:00+00:00", "2026-04-17T20:00:00+00:00",
+                 "ok", 1, 1, 0),
+            ],
+        )
+        conn.commit()
+
+        snap = build_snapshot(
+            conn, as_of_date=AS_OF, user_id=USER,
+            now_local=datetime(2026, 5, 1, 10, 0),
+        )
+    finally:
+        conn.close()
+
+    sources = snap["sources"]
+    assert set(sources.keys()) == {"garmin", "nutrition_manual"}
+
+    # anchor is 2026-04-18T00:00+00:00; freshest garmin ok sync at
+    # 2026-04-17T06:00 → 18h stale. nutrition at 20:00 → 4h stale.
+    assert sources["garmin"]["last_successful_sync_at"] == "2026-04-17T06:00:00+00:00"
+    assert sources["garmin"]["staleness_hours"] == 18.0
+    assert sources["nutrition_manual"]["last_successful_sync_at"] == "2026-04-17T20:00:00+00:00"
+    assert sources["nutrition_manual"]["staleness_hours"] == 4.0
 
 
 # ---------------------------------------------------------------------------

--- a/safety/tests/test_state_store.py
+++ b/safety/tests/test_state_store.py
@@ -109,6 +109,7 @@ def test_schema_migrations_has_one_row_per_applied_migration(tmp_path: Path):
         (5, "005_strength_expansion.sql"),
         (6, "006_nutrition_macros_only.sql"),
         (7, "007_user_memory.sql"),
+        (8, "008_sync_run_log.sql"),
     ]
 
 
@@ -124,7 +125,7 @@ def test_schema_migrations_not_duplicated_on_repeat_init(tmp_path: Path):
     finally:
         conn.close()
 
-    assert count == 7
+    assert count == 8
 
 
 def test_current_schema_version_zero_on_empty_db(tmp_path: Path):
@@ -142,7 +143,7 @@ def test_current_schema_version_matches_head_after_init(tmp_path: Path):
 
     conn = open_connection(db_path)
     try:
-        assert current_schema_version(conn) == 7
+        assert current_schema_version(conn) == 8
     finally:
         conn.close()
 
@@ -281,8 +282,8 @@ def test_cli_state_migrate_on_head_db_reports_empty_applied(tmp_path: Path, caps
 
     import json
     payload = json.loads(capsys.readouterr().out)
-    assert payload["schema_version_before"] == 7
-    assert payload["schema_version_after"] == 7
+    assert payload["schema_version_before"] == 8
+    assert payload["schema_version_after"] == 8
     assert payload["applied"] == []
 
 
@@ -353,7 +354,7 @@ def test_broken_migration_rolls_back_ddl_and_bookkeeping(tmp_path: Path):
         assert len(rows) == 1
 
         # Version is still at head (pre-broken migration), not 99.
-        assert current_schema_version(conn) == 7
+        assert current_schema_version(conn) == 8
     finally:
         conn.close()
 

--- a/safety/tests/test_sync_run_log.py
+++ b/safety/tests/test_sync_run_log.py
@@ -1,0 +1,274 @@
+"""Tests for the ``sync_run_log`` write API + freshness reader.
+
+Covers:
+  - ``begin_sync`` / ``complete_sync`` / ``fail_sync`` round trip.
+  - The ``sync_run`` context manager stitches begin+complete on
+    success and begin+fail on exception.
+  - ``latest_successful_sync_per_source`` returns the right row per
+    source (newest wins; non-ok rows ignored).
+  - The ``idx_sync_run_log_source_user_date`` index is actually used
+    by the freshness lookup (``EXPLAIN QUERY PLAN``).
+
+Tests open the DB directly via ``initialize_database`` + a local seed
+so they don't depend on the CLI sync-wrapping plumbing.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from health_agent_infra.core.state import (
+    begin_sync,
+    complete_sync,
+    fail_sync,
+    initialize_database,
+    latest_successful_sync_per_source,
+    open_connection,
+    sync_run,
+)
+
+
+USER = "u_sync_test"
+
+
+def _fresh_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "state.db"
+    initialize_database(db_path)
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Primitives: begin → complete / fail
+# ---------------------------------------------------------------------------
+
+
+def test_begin_then_complete_round_trip(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        sync_id = begin_sync(
+            conn,
+            source="garmin",
+            user_id=USER,
+            mode="csv",
+            for_date=date(2026, 4, 17),
+        )
+        # Row is created immediately with status='failed' as pessimistic
+        # default — a crash before complete_sync leaves a truthful trail.
+        row_pre = conn.execute(
+            "SELECT * FROM sync_run_log WHERE sync_id = ?", (sync_id,),
+        ).fetchone()
+        assert row_pre["status"] == "failed"
+        assert row_pre["completed_at"] is None
+
+        complete_sync(
+            conn, sync_id,
+            rows_pulled=1,
+            rows_accepted=1,
+            duplicates_skipped=0,
+        )
+        row = conn.execute(
+            "SELECT * FROM sync_run_log WHERE sync_id = ?", (sync_id,),
+        ).fetchone()
+        assert row["source"] == "garmin"
+        assert row["user_id"] == USER
+        assert row["mode"] == "csv"
+        assert row["status"] == "ok"
+        assert row["completed_at"] is not None
+        assert row["rows_pulled"] == 1
+        assert row["rows_accepted"] == 1
+        assert row["duplicates_skipped"] == 0
+        assert row["for_date"] == "2026-04-17"
+        assert row["error_class"] is None
+    finally:
+        conn.close()
+
+
+def test_begin_then_fail_round_trip(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        sync_id = begin_sync(
+            conn, source="garmin_live", user_id=USER, mode="live",
+            for_date=date(2026, 4, 17),
+        )
+        fail_sync(
+            conn, sync_id,
+            error_class="GarminLiveError",
+            error_message="upstream 503",
+        )
+        row = conn.execute(
+            "SELECT * FROM sync_run_log WHERE sync_id = ?", (sync_id,),
+        ).fetchone()
+        assert row["status"] == "failed"
+        assert row["error_class"] == "GarminLiveError"
+        assert row["error_message"] == "upstream 503"
+        assert row["completed_at"] is not None
+        assert row["rows_pulled"] is None
+    finally:
+        conn.close()
+
+
+def test_complete_sync_rejects_invalid_status(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        sync_id = begin_sync(conn, source="x", user_id=USER, mode="csv")
+        with pytest.raises(ValueError):
+            complete_sync(
+                conn, sync_id,
+                rows_pulled=0, rows_accepted=0, duplicates_skipped=0,
+                status="bogus",
+            )
+    finally:
+        conn.close()
+
+
+def test_partial_status_round_trip(tmp_path):
+    """'partial' is a valid terminal status — reserved for partial-day
+    fetches (M6's retry-surface work)."""
+
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        sync_id = begin_sync(conn, source="garmin_live", user_id=USER, mode="live")
+        complete_sync(
+            conn, sync_id,
+            rows_pulled=3, rows_accepted=2, duplicates_skipped=0,
+            status="partial",
+        )
+        row = conn.execute(
+            "SELECT status FROM sync_run_log WHERE sync_id = ?", (sync_id,),
+        ).fetchone()
+        assert row["status"] == "partial"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+def test_sync_run_context_manager_completes_on_clean_exit(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        with sync_run(
+            conn, source="nutrition_manual", user_id=USER,
+            mode="manual", for_date=date(2026, 4, 17),
+        ) as run:
+            run["rows_pulled"] = 1
+            run["rows_accepted"] = 1
+            run["duplicates_skipped"] = 0
+
+        rows = conn.execute(
+            "SELECT * FROM sync_run_log WHERE source = ?",
+            ("nutrition_manual",),
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["status"] == "ok"
+        assert rows[0]["rows_accepted"] == 1
+    finally:
+        conn.close()
+
+
+def test_sync_run_context_manager_fails_on_exception(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            with sync_run(
+                conn, source="garmin_live", user_id=USER, mode="live",
+            ):
+                raise RuntimeError("boom")
+
+        row = conn.execute(
+            "SELECT * FROM sync_run_log WHERE source = ?", ("garmin_live",),
+        ).fetchone()
+        assert row["status"] == "failed"
+        assert row["error_class"] == "RuntimeError"
+        assert row["error_message"] == "boom"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Freshness reader
+# ---------------------------------------------------------------------------
+
+
+def test_latest_successful_sync_returns_newest_ok_per_source(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        # Three successful syncs for garmin, at different times. The
+        # reader should return the newest. started_at is the ordering key.
+        conn.execute(
+            "INSERT INTO sync_run_log "
+            "(source, user_id, mode, started_at, completed_at, status, "
+            " rows_pulled, rows_accepted, duplicates_skipped) "
+            "VALUES "
+            "('garmin', ?, 'csv', '2026-04-15T10:00:00+00:00', '2026-04-15T10:00:05+00:00', 'ok', 1, 1, 0),"
+            "('garmin', ?, 'csv', '2026-04-16T10:00:00+00:00', '2026-04-16T10:00:05+00:00', 'ok', 1, 1, 0),"
+            "('garmin', ?, 'csv', '2026-04-17T10:00:00+00:00', '2026-04-17T10:00:05+00:00', 'ok', 1, 1, 0),"
+            # An intervening failed run — must not surface.
+            "('garmin', ?, 'csv', '2026-04-17T12:00:00+00:00', '2026-04-17T12:00:02+00:00', 'failed', NULL, NULL, NULL),"
+            # A different user's row — filtered by user_id.
+            "('garmin', 'other_user', 'csv', '2026-04-18T10:00:00+00:00', '2026-04-18T10:00:05+00:00', 'ok', 1, 1, 0),"
+            # A second source for the same user.
+            "('nutrition_manual', ?, 'manual', '2026-04-17T18:00:00+00:00', '2026-04-17T18:00:01+00:00', 'ok', 1, 1, 0)",
+            (USER, USER, USER, USER, USER),
+        )
+        conn.commit()
+
+        latest = latest_successful_sync_per_source(conn, user_id=USER)
+        assert set(latest.keys()) == {"garmin", "nutrition_manual"}
+        assert latest["garmin"]["completed_at"] == "2026-04-17T10:00:05+00:00"
+        assert latest["nutrition_manual"]["completed_at"] == "2026-04-17T18:00:01+00:00"
+    finally:
+        conn.close()
+
+
+def test_latest_successful_sync_empty_on_fresh_db(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        assert latest_successful_sync_per_source(conn, user_id=USER) == {}
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Index usage — EXPLAIN QUERY PLAN asserts the index carries the load
+# ---------------------------------------------------------------------------
+
+
+def test_freshness_lookup_uses_source_user_date_index(tmp_path):
+    """The (source, user_id, started_at DESC) index must cover the
+    natural "most recent ok sync per (source, user)" query. Assert via
+    EXPLAIN QUERY PLAN so a future change to the query shape (or an
+    accidental DROP INDEX in a migration) surfaces here, not in a
+    hai-doctor slowdown production discovers."""
+
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        plan = conn.execute(
+            "EXPLAIN QUERY PLAN "
+            "SELECT * FROM sync_run_log "
+            "WHERE source = ? AND user_id = ? AND status = 'ok' "
+            "ORDER BY started_at DESC LIMIT 1",
+            ("garmin", USER),
+        ).fetchall()
+        plan_text = "\n".join(row["detail"] for row in plan)
+        assert "idx_sync_run_log_source_user_date" in plan_text, (
+            f"freshness lookup should use idx_sync_run_log_source_user_date; "
+            f"got plan:\n{plan_text}"
+        )
+    finally:
+        conn.close()

--- a/src/health_agent_infra/cli.py
+++ b/src/health_agent_infra/cli.py
@@ -120,14 +120,30 @@ def _emit_json(obj: Any) -> None:
 
 def cmd_pull(args: argparse.Namespace) -> int:
     as_of = _coerce_date(args.date)
+    mode = "live" if getattr(args, "live", False) else "csv"
+    # The source label is known up front for CSV (fixed adapter class);
+    # for live pulls we still use "garmin_live" — _build_live_adapter
+    # either returns a GarminLiveAdapter whose source_name is the
+    # canonical label, or raises, in which case we log the attempt
+    # against that same label.
+    source_label = "garmin_live" if mode == "live" else GarminRecoveryReadinessAdapter.source_name
 
-    if getattr(args, "live", False):
+    sync_id = _open_sync_row(
+        getattr(args, "db_path", None),
+        source=source_label,
+        user_id=args.user_id,
+        mode=mode,
+        for_date=as_of,
+    )
+
+    if mode == "live":
         try:
             adapter = _build_live_adapter(args)
         except GarminLiveError as exc:
             # Credential-resolution failure — the caller controls this
             # (run `hai auth garmin` or set env vars), so it's USER_INPUT
             # rather than a transient vendor issue.
+            _close_sync_row_failed(args.db_path, sync_id, exc)
             print(f"live pull error: {exc}", file=sys.stderr)
             return exit_codes.USER_INPUT
     else:
@@ -137,6 +153,7 @@ def cmd_pull(args: argparse.Namespace) -> int:
         pull = adapter.load(as_of)
     except GarminLiveError as exc:
         # Vendor API blip (5xx, rate limit, network) — a retry may fix it.
+        _close_sync_row_failed(args.db_path, sync_id, exc)
         print(f"live pull error: {exc}", file=sys.stderr)
         return exit_codes.TRANSIENT
 
@@ -145,6 +162,18 @@ def cmd_pull(args: argparse.Namespace) -> int:
         manual = json.loads(Path(args.manual_readiness_json).read_text(encoding="utf-8"))
     elif args.use_default_manual_readiness:
         manual = default_manual_readiness(as_of)
+
+    # rows_pulled: 1 if we got a daily summary row; 0 otherwise. This
+    # maps "one logical day's evidence = one row" without pretending the
+    # per-metric arrays are independent rows.
+    rows = 1 if pull.get("raw_daily_row") is not None else 0
+    _close_sync_row_ok(
+        args.db_path,
+        sync_id,
+        rows_pulled=rows,
+        rows_accepted=rows,
+        duplicates_skipped=0,
+    )
 
     payload = {
         "as_of_date": as_of.isoformat(),
@@ -155,6 +184,164 @@ def cmd_pull(args: argparse.Namespace) -> int:
     }
     _emit_json(payload)
     return exit_codes.OK
+
+
+# ---------------------------------------------------------------------------
+# Sync-log CLI shim — best-effort wrappers around core/state/sync_log
+#
+# All three helpers silently skip if the DB file is absent. Sync logging
+# is lighter-weight telemetry than the accepted-state projections
+# (which emit stderr warnings on failure) — an operator who hasn't run
+# `hai state init` shouldn't see stderr noise every time they pull.
+# ---------------------------------------------------------------------------
+
+
+def _open_sync_row(
+    db_path_arg,
+    *,
+    source: str,
+    user_id: str,
+    mode: str,
+    for_date,
+):
+    from health_agent_infra.core.state import (
+        begin_sync,
+        open_connection,
+        resolve_db_path,
+    )
+
+    db_path = resolve_db_path(db_path_arg)
+    if not db_path.exists():
+        return None
+    conn = open_connection(db_path)
+    try:
+        return begin_sync(
+            conn,
+            source=source,
+            user_id=user_id,
+            mode=mode,
+            for_date=for_date,
+        )
+    except sqlite3.OperationalError:
+        # Pre-migration-008 DB: skip quietly.
+        return None
+    finally:
+        conn.close()
+
+
+def _close_sync_row_ok(
+    db_path_arg,
+    sync_id,
+    *,
+    rows_pulled,
+    rows_accepted,
+    duplicates_skipped,
+    status: str = "ok",
+) -> None:
+    if sync_id is None:
+        return
+    from health_agent_infra.core.state import (
+        complete_sync,
+        open_connection,
+        resolve_db_path,
+    )
+
+    db_path = resolve_db_path(db_path_arg)
+    if not db_path.exists():
+        return
+    conn = open_connection(db_path)
+    try:
+        complete_sync(
+            conn,
+            sync_id,
+            rows_pulled=rows_pulled,
+            rows_accepted=rows_accepted,
+            duplicates_skipped=duplicates_skipped,
+            status=status,
+        )
+    except sqlite3.OperationalError:
+        return
+    finally:
+        conn.close()
+
+
+def _close_sync_row_failed(db_path_arg, sync_id, exc: BaseException) -> None:
+    if sync_id is None:
+        return
+    from health_agent_infra.core.state import (
+        fail_sync,
+        open_connection,
+        resolve_db_path,
+    )
+
+    db_path = resolve_db_path(db_path_arg)
+    if not db_path.exists():
+        return
+    conn = open_connection(db_path)
+    try:
+        fail_sync(
+            conn,
+            sync_id,
+            error_class=type(exc).__name__,
+            error_message=str(exc),
+        )
+    except sqlite3.OperationalError:
+        return
+    finally:
+        conn.close()
+
+
+def _sync_if_db(
+    db_path_arg,
+    *,
+    source: str,
+    user_id: str,
+    mode: str,
+    for_date=None,
+):
+    """Context manager: write a sync_run_log row if the DB exists, else no-op.
+
+    Yields a mutable dict the caller fills in before exit
+    (``run["rows_pulled"] = N`` etc.). Exceptions re-raise after the
+    row is closed with ``fail_sync``. When the DB is absent or predates
+    migration 008 the yielded dict has no ``sync_id`` and nothing is
+    written.
+    """
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _cm():
+        sync_id = _open_sync_row(
+            db_path_arg,
+            source=source,
+            user_id=user_id,
+            mode=mode,
+            for_date=for_date,
+        )
+        run: dict = {
+            "sync_id": sync_id,
+            "rows_pulled": None,
+            "rows_accepted": None,
+            "duplicates_skipped": None,
+            "status": "ok",
+        }
+        try:
+            yield run
+        except Exception as exc:
+            _close_sync_row_failed(db_path_arg, sync_id, exc)
+            raise
+        else:
+            _close_sync_row_ok(
+                db_path_arg,
+                sync_id,
+                rows_pulled=run.get("rows_pulled"),
+                rows_accepted=run.get("rows_accepted"),
+                duplicates_skipped=run.get("duplicates_skipped"),
+                status=run.get("status", "ok"),
+            )
+
+    return _cm()
 
 
 def _build_live_adapter(args: argparse.Namespace):
@@ -1224,11 +1411,22 @@ def cmd_intake_gym(args: argparse.Namespace) -> int:
         submitted_at=issued_at,
     )
 
-    # JSONL audit first (durable boundary). If this fails, nothing landed.
-    jsonl_path = append_submission_jsonl(submission, base_dir=base_dir)
+    with _sync_if_db(
+        args.db_path,
+        source="gym_manual",
+        user_id=submission.user_id,
+        mode="manual",
+        for_date=submission.as_of_date,
+    ) as run:
+        # JSONL audit first (durable boundary). If this fails, nothing landed.
+        jsonl_path = append_submission_jsonl(submission, base_dir=base_dir)
 
-    # DB projection is atomic + fail-soft.
-    _project_gym_submission_into_state(args.db_path, submission)
+        # DB projection is atomic + fail-soft.
+        _project_gym_submission_into_state(args.db_path, submission)
+
+        run["rows_pulled"] = len(submission.sets)
+        run["rows_accepted"] = len(submission.sets)
+        run["duplicates_skipped"] = 0
 
     _emit_json({
         "submission_id": submission.submission_id,
@@ -1386,6 +1584,18 @@ def cmd_intake_exercise(args: argparse.Namespace) -> int:
         )
         return 2
 
+    # Exercise-taxonomy entries are global (not per-user), so sync rows
+    # here use a "global" sentinel — the snapshot's user-scoped
+    # freshness query won't surface them, which is intentional: these
+    # are config-shaped events, not data-ingest ones.
+    sync_id = _open_sync_row(
+        args.db_path,
+        source="exercise_taxonomy_manual",
+        user_id="global",
+        mode="manual",
+        for_date=None,
+    )
+
     conn = open_connection(db_path)
     try:
         try:
@@ -1401,6 +1611,7 @@ def cmd_intake_exercise(args: argparse.Namespace) -> int:
                 source="user_manual",
             )
         except sqlite3.IntegrityError as exc:
+            _close_sync_row_failed(args.db_path, sync_id, exc)
             print(f"intake exercise rejected: {exc}", file=sys.stderr)
             return 2
 
@@ -1416,6 +1627,14 @@ def cmd_intake_exercise(args: argparse.Namespace) -> int:
         ).fetchone()
     finally:
         conn.close()
+
+    _close_sync_row_ok(
+        args.db_path,
+        sync_id,
+        rows_pulled=1 if inserted else 0,
+        rows_accepted=1 if inserted else 0,
+        duplicates_skipped=0 if inserted else 1,
+    )
 
     _emit_json({
         "inserted": inserted,
@@ -1519,12 +1738,23 @@ def cmd_intake_nutrition(args: argparse.Namespace) -> int:
         supersedes_submission_id=supersedes_id,
     )
 
-    # JSONL audit first (durable boundary). base_dir was resolved above for
-    # correction-chain lookup; re-use it here.
-    jsonl_path = append_submission_jsonl(submission, base_dir=base_dir)
+    with _sync_if_db(
+        args.db_path,
+        source="nutrition_manual",
+        user_id=submission.user_id,
+        mode="manual",
+        for_date=submission.as_of_date,
+    ) as run:
+        # JSONL audit first (durable boundary). base_dir was resolved above for
+        # correction-chain lookup; re-use it here.
+        jsonl_path = append_submission_jsonl(submission, base_dir=base_dir)
 
-    # DB projection is atomic + fail-soft.
-    _project_nutrition_submission_into_state(args.db_path, submission)
+        # DB projection is atomic + fail-soft.
+        _project_nutrition_submission_into_state(args.db_path, submission)
+
+        run["rows_pulled"] = 1
+        run["rows_accepted"] = 1
+        run["duplicates_skipped"] = 0
 
     _emit_json({
         "submission_id": submission.submission_id,
@@ -1679,9 +1909,19 @@ def cmd_intake_stress(args: argparse.Namespace) -> int:
         supersedes_submission_id=supersedes_id,
     )
 
-    jsonl_path = append_submission_jsonl(submission, base_dir=base_dir)
+    with _sync_if_db(
+        args.db_path,
+        source="stress_manual",
+        user_id=submission.user_id,
+        mode="manual",
+        for_date=submission.as_of_date,
+    ) as run:
+        jsonl_path = append_submission_jsonl(submission, base_dir=base_dir)
+        _project_stress_submission_into_state(args.db_path, submission)
 
-    _project_stress_submission_into_state(args.db_path, submission)
+        run["rows_pulled"] = 1
+        run["rows_accepted"] = 1
+        run["duplicates_skipped"] = 0
 
     _emit_json({
         "submission_id": submission.submission_id,
@@ -1802,8 +2042,19 @@ def cmd_intake_note(args: argparse.Namespace) -> int:
         ingest_actor=args.ingest_actor,
     )
 
-    jsonl_path = append_note_jsonl(note, base_dir=base_dir)
-    _project_context_note_into_state(args.db_path, note)
+    with _sync_if_db(
+        args.db_path,
+        source="note_manual",
+        user_id=note.user_id,
+        mode="manual",
+        for_date=note.as_of_date,
+    ) as run:
+        jsonl_path = append_note_jsonl(note, base_dir=base_dir)
+        _project_context_note_into_state(args.db_path, note)
+
+        run["rows_pulled"] = 1
+        run["rows_accepted"] = 1
+        run["duplicates_skipped"] = 0
 
     _emit_json({
         "note_id": note.note_id,
@@ -2945,6 +3196,10 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Trailing window size for resting_hr / hrv / "
                              "training_load series (live pull only). Matches "
                              "the CSV adapter default.")
+    p_pull.add_argument("--db-path", default=None,
+                        help="State DB path for sync_run_log writes. Best-effort — "
+                             "if the DB is absent, the pull still runs but the "
+                             "sync row is skipped. Same semantics as `hai writeback`.")
     p_pull.set_defaults(func=cmd_pull)
 
     p_auth = sub.add_parser("auth", help="Credential management for external sources")

--- a/src/health_agent_infra/core/state/__init__.py
+++ b/src/health_agent_infra/core/state/__init__.py
@@ -51,17 +51,28 @@ from health_agent_infra.core.state.store import (
     open_connection,
     resolve_db_path,
 )
+from health_agent_infra.core.state.sync_log import (
+    begin_sync,
+    complete_sync,
+    fail_sync,
+    latest_successful_sync_per_source,
+    sync_run,
+)
 
 __all__ = [
     "DEFAULT_DB_PATH",
     "ReprojectBaseDirError",
     "apply_pending_migrations",
     "available_domains",
+    "begin_sync",
     "build_snapshot",
+    "complete_sync",
     "current_schema_version",
     "delete_canonical_plan_cascade",
+    "fail_sync",
     "initialize_database",
     "latest_nutrition_submission_id",
+    "latest_successful_sync_per_source",
     "link_proposal_to_plan",
     "mark_plan_superseded",
     "merge_manual_stress_into_accepted_recovery",
@@ -93,4 +104,5 @@ __all__ = [
     "read_proposals_for_plan_key",
     "reproject_from_jsonl",
     "resolve_db_path",
+    "sync_run",
 ]

--- a/src/health_agent_infra/core/state/migrations/008_sync_run_log.sql
+++ b/src/health_agent_infra/core/state/migrations/008_sync_run_log.sql
@@ -1,0 +1,55 @@
+-- Migration 008 — sync_run_log (M2 of the post-v0.1.0 hardening plan).
+--
+-- Records one row per sync entry point invocation (``hai pull`` +
+-- ``hai intake *``) so freshness ("when did each source last succeed?")
+-- is a single SELECT away instead of requiring the operator to scan
+-- JSONL files. See the hardening plan §M2.
+--
+-- Row lifecycle:
+--   1. ``begin_sync`` inserts with ``started_at`` + ``status='failed'``
+--      (pessimistic default — a crash between begin and complete leaves
+--      the row in a truthful "we started and never confirmed" state).
+--   2. On success, ``complete_sync`` updates ``completed_at`` +
+--      ``status='ok'`` (or ``'partial'`` for partial-success fetches
+--      deferred to M6) + the three counts.
+--   3. On exception, ``fail_sync`` stamps ``completed_at`` +
+--      ``error_class`` + ``error_message``; ``status`` stays
+--      ``'failed'``.
+--
+-- Counts (``rows_pulled``, ``rows_accepted``, ``duplicates_skipped``)
+-- are nullable: not every source has a meaningful count. For a
+-- single-day Garmin pull, ``rows_pulled=1`` (the raw daily row is the
+-- unit); for a gym intake, ``rows_pulled=len(sets)``. Callers that
+-- don't produce meaningful counts leave them NULL rather than inventing
+-- zeros.
+--
+-- ``for_date`` is the civil date the sync was *for* (the ``as_of``
+-- argument). It is NULL when a sync doesn't carry a civil-date frame.
+--
+-- The index covers the snapshot's freshness query:
+--   "SELECT ... FROM sync_run_log
+--    WHERE source = ? AND user_id = ? AND status = 'ok'
+--    ORDER BY started_at DESC LIMIT 1"
+-- The (source, user_id, started_at DESC) leading keys match that
+-- predicate exactly; status is filtered post-index-scan but the
+-- working set per (source, user_id) is small.
+
+CREATE TABLE sync_run_log (
+  sync_id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  source             TEXT NOT NULL,
+  user_id            TEXT NOT NULL,
+  mode               TEXT NOT NULL,
+  started_at         TEXT NOT NULL,
+  completed_at       TEXT,
+  status             TEXT NOT NULL,
+  rows_pulled        INTEGER,
+  rows_accepted      INTEGER,
+  duplicates_skipped INTEGER,
+  for_date           TEXT,
+  error_class        TEXT,
+  error_message      TEXT,
+  CHECK (status IN ('ok','partial','failed'))
+);
+
+CREATE INDEX idx_sync_run_log_source_user_date
+  ON sync_run_log(source, user_id, started_at DESC);

--- a/src/health_agent_infra/core/state/snapshot.py
+++ b/src/health_agent_infra/core/state/snapshot.py
@@ -388,6 +388,13 @@ def build_snapshot(
     # X-rules (see memory_model.md §2.1 + roadmap §3.1 decision 4).
     user_memory_block = _user_memory_block(conn, as_of_date=as_of_date, user_id=user_id)
 
+    # Sources freshness (M2) — per-source last-successful sync timestamp +
+    # staleness against as_of_date. Source of truth is sync_run_log
+    # (migration 008); consumers can answer "how fresh is the evidence
+    # I'm reasoning over?" without reading JSONL files. Empty dict on a
+    # pre-008 DB — the block is still present, just unpopulated.
+    sources_block = _sources_block(conn, as_of_date=as_of_date, user_id=user_id)
+
     # Stress (Phase 3): first-class domain on its own accepted table.
     # Two origins co-own it: Garmin (garmin_all_day_stress +
     # body_battery_end_of_day) and user_manual (manual_stress_score).
@@ -647,6 +654,7 @@ def build_snapshot(
             "recent": recent_revs,
         },
         "user_memory": user_memory_block,
+        "sources": sources_block,
     }
 
 
@@ -788,6 +796,75 @@ def _nutrition_classified_to_dict(classified: Any) -> dict[str, Any]:
         "derivation_path": classified.derivation_path,
         "uncertainty": list(classified.uncertainty),
     }
+
+
+def _sources_block(
+    conn: sqlite3.Connection,
+    *,
+    as_of_date: date,
+    user_id: str,
+) -> dict[str, Any]:
+    """Return ``{source: {last_successful_sync_at, staleness_hours}}`` for
+    every source that has ever completed a sync for ``user_id``.
+
+    Staleness is measured from the end of ``as_of_date`` (00:00 UTC on
+    the following day) so historical snapshots don't report absurd
+    "3 years stale" values for evidence that was fresh when the plan
+    ran. A negative staleness (sync completed *after* as_of_date ends)
+    is possible for backfill runs; we let it through rather than
+    clamping, because the honest signal "this evidence was recorded
+    after the civil date it describes" is the kind of thing an auditor
+    might want to flag.
+
+    Pre-008 DB: ``latest_successful_sync_per_source`` returns an empty
+    dict, and this function mirrors that shape so the snapshot stays
+    alive on older DBs.
+    """
+
+    from health_agent_infra.core.state.sync_log import (
+        latest_successful_sync_per_source,
+    )
+
+    rows_by_source = latest_successful_sync_per_source(conn, user_id=user_id)
+    if not rows_by_source:
+        return {}
+
+    # Reference point: 00:00 UTC on the day AFTER as_of_date (i.e. the
+    # instant as_of_date ends). Using end-of-day gives a stable anchor
+    # that doesn't drift between test runs or across timezones.
+    anchor = datetime.combine(
+        as_of_date + timedelta(days=1), time.min, tzinfo=timezone.utc,
+    )
+
+    out: dict[str, Any] = {}
+    for source, row in rows_by_source.items():
+        completed_at_str = row.get("completed_at") or row.get("started_at")
+        if not completed_at_str:
+            # Shouldn't happen — the query filters on status='ok' which
+            # requires complete_sync to have stamped completed_at. Fall
+            # through rather than raising so one malformed row doesn't
+            # blow up the whole snapshot.
+            out[source] = {
+                "last_successful_sync_at": None,
+                "staleness_hours": None,
+            }
+            continue
+        try:
+            completed_at = datetime.fromisoformat(completed_at_str)
+        except ValueError:
+            out[source] = {
+                "last_successful_sync_at": completed_at_str,
+                "staleness_hours": None,
+            }
+            continue
+        if completed_at.tzinfo is None:
+            completed_at = completed_at.replace(tzinfo=timezone.utc)
+        staleness_hours = (anchor - completed_at).total_seconds() / 3600.0
+        out[source] = {
+            "last_successful_sync_at": completed_at.isoformat(),
+            "staleness_hours": round(staleness_hours, 2),
+        }
+    return out
 
 
 def _user_memory_block(

--- a/src/health_agent_infra/core/state/sync_log.py
+++ b/src/health_agent_infra/core/state/sync_log.py
@@ -1,0 +1,215 @@
+"""Sync-run bookkeeping — write + read helpers for ``sync_run_log``.
+
+Three primitive functions (``begin_sync`` / ``complete_sync`` /
+``fail_sync``) map 1:1 to the row lifecycle in migration 008 and cover
+the write surface for every sync entry point. A thin context manager
+(:func:`sync_run`) stitches them together so callers can wrap a block
+without manual try/except scaffolding.
+
+Callers that already manage their own transactions should call the
+primitives directly; callers that want the "open row, do work, close
+row" ergonomics should use the context manager. Both write to the same
+table.
+
+Reader: :func:`latest_successful_sync_per_source` returns the most
+recent ``status='ok'`` row per source for a given user. The snapshot's
+``sources`` freshness block consumes this.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from datetime import date, datetime, timezone
+from typing import Any, Iterator, Literal, Optional
+
+
+SyncStatus = Literal["ok", "partial", "failed"]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def begin_sync(
+    conn: sqlite3.Connection,
+    *,
+    source: str,
+    user_id: str,
+    mode: str,
+    for_date: Optional[date] = None,
+) -> int:
+    """Open a new sync row and return its ``sync_id``.
+
+    The row is inserted with ``status='failed'`` as a pessimistic
+    default — a crash between this call and a later :func:`complete_sync`
+    leaves the row truthfully reflecting "we started and never
+    confirmed." The row is finalised by a following :func:`complete_sync`
+    or :func:`fail_sync`.
+    """
+
+    cursor = conn.execute(
+        "INSERT INTO sync_run_log "
+        "(source, user_id, mode, started_at, status, for_date) "
+        "VALUES (?, ?, ?, ?, 'failed', ?)",
+        (
+            source,
+            user_id,
+            mode,
+            _now_iso(),
+            for_date.isoformat() if for_date is not None else None,
+        ),
+    )
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+def complete_sync(
+    conn: sqlite3.Connection,
+    sync_id: int,
+    *,
+    rows_pulled: Optional[int],
+    rows_accepted: Optional[int],
+    duplicates_skipped: Optional[int],
+    status: SyncStatus = "ok",
+) -> None:
+    """Stamp ``completed_at`` + counts + final status on an open sync row.
+
+    ``status`` defaults to ``'ok'``; pass ``'partial'`` for a fetch that
+    succeeded on some field calls and failed on others (surface reserved
+    for M6's partial-day recovery). ``'failed'`` is reachable but
+    callers that already know they failed should call
+    :func:`fail_sync` instead so the error_class / error_message columns
+    get populated.
+    """
+
+    if status not in ("ok", "partial", "failed"):
+        raise ValueError(
+            f"complete_sync: status must be one of 'ok','partial','failed'; "
+            f"got {status!r}"
+        )
+    conn.execute(
+        "UPDATE sync_run_log SET "
+        "  completed_at = ?, status = ?, "
+        "  rows_pulled = ?, rows_accepted = ?, duplicates_skipped = ? "
+        "WHERE sync_id = ?",
+        (_now_iso(), status, rows_pulled, rows_accepted, duplicates_skipped, sync_id),
+    )
+    conn.commit()
+
+
+def fail_sync(
+    conn: sqlite3.Connection,
+    sync_id: int,
+    *,
+    error_class: str,
+    error_message: str,
+) -> None:
+    """Stamp ``completed_at`` + error metadata on an open sync row.
+
+    ``status`` stays ``'failed'`` (the default from :func:`begin_sync`).
+    """
+
+    conn.execute(
+        "UPDATE sync_run_log SET "
+        "  completed_at = ?, status = 'failed', "
+        "  error_class = ?, error_message = ? "
+        "WHERE sync_id = ?",
+        (_now_iso(), error_class, error_message, sync_id),
+    )
+    conn.commit()
+
+
+@contextmanager
+def sync_run(
+    conn: sqlite3.Connection,
+    *,
+    source: str,
+    user_id: str,
+    mode: str,
+    for_date: Optional[date] = None,
+) -> Iterator[dict[str, Any]]:
+    """Context manager wrapping begin/complete/fail.
+
+    Yields a mutable dict the caller fills in before exit:
+
+        with sync_run(conn, source="garmin", user_id=u, mode="csv") as run:
+            ...do the work...
+            run["rows_pulled"] = 1
+            run["rows_accepted"] = 1
+            run["duplicates_skipped"] = 0
+
+    On normal exit the values present in the dict are passed to
+    :func:`complete_sync` (missing keys → NULL columns). On exception
+    :func:`fail_sync` is called with ``error_class = type(exc).__name__``
+    and the exception's ``str()`` as the message. The exception then
+    re-raises so callers can still handle it.
+    """
+
+    sync_id = begin_sync(
+        conn,
+        source=source,
+        user_id=user_id,
+        mode=mode,
+        for_date=for_date,
+    )
+    run: dict[str, Any] = {
+        "sync_id": sync_id,
+        "rows_pulled": None,
+        "rows_accepted": None,
+        "duplicates_skipped": None,
+        "status": "ok",
+    }
+    try:
+        yield run
+    except Exception as exc:
+        fail_sync(
+            conn,
+            sync_id,
+            error_class=type(exc).__name__,
+            error_message=str(exc),
+        )
+        raise
+    else:
+        complete_sync(
+            conn,
+            sync_id,
+            rows_pulled=run.get("rows_pulled"),
+            rows_accepted=run.get("rows_accepted"),
+            duplicates_skipped=run.get("duplicates_skipped"),
+            status=run.get("status", "ok"),
+        )
+
+
+def latest_successful_sync_per_source(
+    conn: sqlite3.Connection,
+    *,
+    user_id: str,
+) -> dict[str, dict[str, Any]]:
+    """Return ``{source: {"sync_id","started_at","completed_at",...}}``.
+
+    One row per source: the most recent ``status='ok'`` run for
+    ``user_id``. Sources that never completed successfully are absent
+    from the result. Used by ``build_snapshot`` to fill the ``sources``
+    freshness block.
+
+    Robust to a DB that predates migration 008: returns an empty dict
+    when the table is missing, so the snapshot surface stays alive.
+    """
+
+    try:
+        rows = conn.execute(
+            "SELECT s.* FROM sync_run_log s "
+            "INNER JOIN ("
+            "  SELECT source, MAX(started_at) AS mx "
+            "  FROM sync_run_log "
+            "  WHERE user_id = ? AND status = 'ok' "
+            "  GROUP BY source"
+            ") last ON s.source = last.source AND s.started_at = last.mx "
+            "WHERE s.user_id = ? AND s.status = 'ok'",
+            (user_id, user_id),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return {}
+
+    return {row["source"]: dict(row) for row in rows}


### PR DESCRIPTION
## Summary
- Migration 008 adds `sync_run_log` + `idx_sync_run_log_source_user_date` for per-source freshness queries.
- New `core/state/sync_log.py`: `begin_sync` / `complete_sync` / `fail_sync` primitives plus a `sync_run` context manager. Row lifecycle: begin inserts with pessimistic `status='failed'` default; complete stamps success + counts; fail stamps `error_class`/`error_message`.
- CLI wiring: `hai pull` (CSV + live) and five `hai intake *` handlers (gym, exercise, nutrition, stress, note) now record a sync row per invocation. Best-effort — silently skipped if DB is absent.
- `build_snapshot` emits a new `sources` block: `{source: {last_successful_sync_at, staleness_hours}}`, anchored at end-of-day-UTC of `as_of_date` so historical snapshots don't report absurd "3 years stale" values.

## Test plan
- [x] `uv run pytest safety/tests -q` — 1352 passing after rebase on M1
- [x] Smoke: `hai pull` writes a sync row; `hai state snapshot` surfaces the `sources` block with correct staleness
- [x] EXPLAIN QUERY PLAN confirms the freshness lookup uses `idx_sync_run_log_source_user_date`