### PR TITLE
M3: recommendation_log.daily_plan_id column + index

### DIFF
--- a/safety/tests/test_migration_009.py
+++ b/safety/tests/test_migration_009.py
@@ -1,0 +1,314 @@
+"""M3 — migration 009 promotes ``daily_plan_id`` to a real column.
+
+Contracts pinned:
+
+  1. Migration 009 adds ``recommendation_log.daily_plan_id`` as a
+     nullable TEXT column.
+  2. The index ``idx_recommendation_log_daily_plan_id`` exists and is
+     used by the natural ``WHERE daily_plan_id = ?`` lookup.
+  3. Backfill: rows that existed pre-009 with ``daily_plan_id`` inside
+     their ``payload_json`` are populated.
+  4. Backfill: legacy rows (pre-synthesis recovery-only path) that
+     have no ``daily_plan_id`` in payload_json stay NULL — the column
+     is intentionally sparse, not invented.
+  5. New writes via ``project_bounded_recommendation`` land the column
+     as well as the payload copy.
+
+Pre-M3 state is simulated by running migrations 001..008 only, seeding
+rows with the legacy schema, then applying 009 against that DB.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from health_agent_infra.core.state import (
+    apply_pending_migrations,
+    current_schema_version,
+    initialize_database,
+    open_connection,
+)
+from health_agent_infra.core.state.projector import (
+    project_bounded_recommendation,
+)
+from health_agent_infra.core.state.store import discover_migrations
+
+
+def _seed_at_v8(tmp_path: Path) -> Path:
+    """Return a DB path with migrations 001..008 applied, NOT 009.
+
+    Filters the packaged migration list to everything strictly before
+    009. The test then runs 009 explicitly so the backfill + column
+    addition are the *only* schema change between seeding and assertion.
+    """
+
+    db = tmp_path / "state.db"
+    all_migrations = discover_migrations()
+    pre_009 = [m for m in all_migrations if m[0] < 9]
+    assert any(version == 8 for version, _, _ in pre_009), (
+        "test assumes migration 008 exists (M2 shipped) — if it doesn't, "
+        "this test's pre-state is different from what it claims to be"
+    )
+    conn = open_connection(db)
+    try:
+        applied = apply_pending_migrations(conn, migrations=pre_009)
+        assert [v for v, _ in applied] == [m[0] for m in pre_009]
+    finally:
+        conn.close()
+    return db
+
+
+def _run_migration_009(db: Path) -> None:
+    all_migrations = discover_migrations()
+    nine = [m for m in all_migrations if m[0] == 9]
+    assert len(nine) == 1, "expected exactly one migration 009"
+    conn = open_connection(db)
+    try:
+        applied = apply_pending_migrations(conn, migrations=nine)
+        assert applied == [(9, "009_recommendation_log_fk.sql")]
+    finally:
+        conn.close()
+
+
+def _recommendation_columns(conn: sqlite3.Connection) -> dict[str, dict]:
+    rows = conn.execute("PRAGMA table_info(recommendation_log)").fetchall()
+    return {row["name"]: dict(row) for row in rows}
+
+
+def _insert_legacy_recommendation(
+    conn: sqlite3.Connection,
+    *,
+    recommendation_id: str,
+    daily_plan_id: str | None,
+) -> None:
+    """Insert a recommendation_log row using the pre-009 schema.
+
+    payload_json carries ``daily_plan_id`` when provided; the column
+    does not exist yet so we simply don't mention it in the INSERT.
+    """
+
+    payload = {
+        "recommendation_id": recommendation_id,
+        "user_id": "u_test",
+        "for_date": "2026-04-17",
+        "issued_at": "2026-04-17T10:00:00+00:00",
+        "action": "proceed_with_planned_run",
+        "confidence": "high",
+        "bounded": True,
+    }
+    if daily_plan_id is not None:
+        payload["daily_plan_id"] = daily_plan_id
+
+    conn.execute(
+        """
+        INSERT INTO recommendation_log (
+            recommendation_id, user_id, for_date, issued_at,
+            action, confidence, bounded, payload_json,
+            jsonl_offset, source, ingest_actor, agent_version,
+            produced_at, validated_at, projected_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            recommendation_id, "u_test", "2026-04-17",
+            "2026-04-17T10:00:00+00:00",
+            "proceed_with_planned_run", "high", 1,
+            json.dumps(payload, sort_keys=True),
+            None, "claude_agent_v1", "claude_agent_v1", None,
+            "2026-04-17T10:00:00+00:00",
+            "2026-04-17T10:00:01+00:00",
+            "2026-04-17T10:00:01+00:00",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Column shape
+# ---------------------------------------------------------------------------
+
+
+def test_daily_plan_id_column_added_as_nullable_text(tmp_path: Path):
+    db = _seed_at_v8(tmp_path)
+    _run_migration_009(db)
+
+    conn = open_connection(db)
+    try:
+        cols = _recommendation_columns(conn)
+    finally:
+        conn.close()
+
+    assert "daily_plan_id" in cols, (
+        f"migration 009 did not add daily_plan_id; columns = {sorted(cols)}"
+    )
+    col = cols["daily_plan_id"]
+    assert col["type"].upper() == "TEXT"
+    assert col["notnull"] == 0, (
+        "daily_plan_id must be nullable — legacy writeback rows carry no "
+        "plan id and should stay NULL after migration"
+    )
+
+
+def test_index_on_daily_plan_id_is_present(tmp_path: Path):
+    db = _seed_at_v8(tmp_path)
+    _run_migration_009(db)
+
+    conn = open_connection(db)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'index' AND tbl_name = 'recommendation_log'"
+        ).fetchall()
+        index_names = {r["name"] for r in rows}
+    finally:
+        conn.close()
+
+    assert "idx_recommendation_log_daily_plan_id" in index_names, (
+        f"expected the new index; found: {sorted(index_names)}"
+    )
+
+
+def test_daily_plan_lookup_uses_new_index(tmp_path: Path):
+    """EXPLAIN QUERY PLAN must show the explain-loader / cascade-delete
+    WHERE clause hits the dedicated index, not a full table scan."""
+
+    db = _seed_at_v8(tmp_path)
+    _run_migration_009(db)
+
+    conn = open_connection(db)
+    try:
+        plan = conn.execute(
+            "EXPLAIN QUERY PLAN "
+            "SELECT recommendation_id FROM recommendation_log "
+            "WHERE daily_plan_id = ?",
+            ("plan_2026-04-17_u_test",),
+        ).fetchall()
+        plan_text = "\n".join(row["detail"] for row in plan)
+    finally:
+        conn.close()
+
+    assert "idx_recommendation_log_daily_plan_id" in plan_text, (
+        f"daily_plan_id lookup should use the dedicated index; "
+        f"got plan:\n{plan_text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backfill behavior
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_populates_column_from_payload_json(tmp_path: Path):
+    db = _seed_at_v8(tmp_path)
+    conn = open_connection(db)
+    try:
+        _insert_legacy_recommendation(
+            conn, recommendation_id="rec_a",
+            daily_plan_id="plan_2026-04-17_u_test",
+        )
+        _insert_legacy_recommendation(
+            conn, recommendation_id="rec_b",
+            daily_plan_id="plan_2026-04-18_u_test",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    _run_migration_009(db)
+
+    conn = open_connection(db)
+    try:
+        rows = dict(conn.execute(
+            "SELECT recommendation_id, daily_plan_id FROM recommendation_log "
+            "ORDER BY recommendation_id"
+        ).fetchall())
+    finally:
+        conn.close()
+
+    assert rows == {
+        "rec_a": "plan_2026-04-17_u_test",
+        "rec_b": "plan_2026-04-18_u_test",
+    }
+
+
+def test_backfill_leaves_legacy_rows_null(tmp_path: Path):
+    """Rows with no daily_plan_id in payload_json (e.g. pre-synthesis
+    recovery-only writeback output) remain NULL. The column is
+    intentionally sparse."""
+
+    db = _seed_at_v8(tmp_path)
+    conn = open_connection(db)
+    try:
+        _insert_legacy_recommendation(
+            conn, recommendation_id="rec_legacy", daily_plan_id=None,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    _run_migration_009(db)
+
+    conn = open_connection(db)
+    try:
+        row = conn.execute(
+            "SELECT daily_plan_id FROM recommendation_log "
+            "WHERE recommendation_id = ?",
+            ("rec_legacy",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row["daily_plan_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Post-migration writer: the projector now populates the column
+# ---------------------------------------------------------------------------
+
+
+def test_project_bounded_recommendation_writes_column_after_migration(tmp_path: Path):
+    db = _seed_at_v8(tmp_path)
+    _run_migration_009(db)
+    # At this point the DB is at v9 but not at packaged HEAD. Bring it
+    # fully up to date (no-op if 009 is HEAD at the time this test
+    # runs, forward-compatible if a later migration lands).
+    initialize_database(db)
+
+    recommendation = {
+        "recommendation_id": "rec_new",
+        "user_id": "u_test",
+        "for_date": "2026-04-18",
+        "issued_at": "2026-04-18T09:00:00+00:00",
+        "action": "proceed_with_planned_run",
+        "confidence": "high",
+        "bounded": True,
+        "domain": "running",
+        "daily_plan_id": "plan_2026-04-18_u_test",
+    }
+    conn = open_connection(db)
+    try:
+        project_bounded_recommendation(conn, recommendation)
+        row = conn.execute(
+            "SELECT daily_plan_id FROM recommendation_log "
+            "WHERE recommendation_id = ?",
+            ("rec_new",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row["daily_plan_id"] == "plan_2026-04-18_u_test"
+
+
+def test_current_schema_version_at_head_is_at_least_nine(tmp_path: Path):
+    """Pin the lower bound so adding migrations 010+ doesn't touch this
+    file. The exact head lives in test_state_store."""
+
+    db = tmp_path / "state.db"
+    initialize_database(db)
+    conn = open_connection(db)
+    try:
+        assert current_schema_version(conn) >= 9
+    finally:
+        conn.close()

--- a/safety/tests/test_state_store.py
+++ b/safety/tests/test_state_store.py
@@ -110,6 +110,7 @@ def test_schema_migrations_has_one_row_per_applied_migration(tmp_path: Path):
         (6, "006_nutrition_macros_only.sql"),
         (7, "007_user_memory.sql"),
         (8, "008_sync_run_log.sql"),
+        (9, "009_recommendation_log_fk.sql"),
     ]
 
 
@@ -125,7 +126,7 @@ def test_schema_migrations_not_duplicated_on_repeat_init(tmp_path: Path):
     finally:
         conn.close()
 
-    assert count == 8
+    assert count == 9
 
 
 def test_current_schema_version_zero_on_empty_db(tmp_path: Path):
@@ -143,7 +144,7 @@ def test_current_schema_version_matches_head_after_init(tmp_path: Path):
 
     conn = open_connection(db_path)
     try:
-        assert current_schema_version(conn) == 8
+        assert current_schema_version(conn) == 9
     finally:
         conn.close()
 
@@ -282,8 +283,8 @@ def test_cli_state_migrate_on_head_db_reports_empty_applied(tmp_path: Path, caps
 
     import json
     payload = json.loads(capsys.readouterr().out)
-    assert payload["schema_version_before"] == 8
-    assert payload["schema_version_after"] == 8
+    assert payload["schema_version_before"] == 9
+    assert payload["schema_version_after"] == 9
     assert payload["applied"] == []
 
 
@@ -354,7 +355,7 @@ def test_broken_migration_rolls_back_ddl_and_bookkeeping(tmp_path: Path):
         assert len(rows) == 1
 
         # Version is still at head (pre-broken migration), not 99.
-        assert current_schema_version(conn) == 8
+        assert current_schema_version(conn) == 9
     finally:
         conn.close()
 

--- a/src/health_agent_infra/core/explain/queries.py
+++ b/src/health_agent_infra/core/explain/queries.py
@@ -331,14 +331,15 @@ def _load_firings_for_plan(
 def _load_recommendations_for_plan(
     conn: sqlite3.Connection, *, daily_plan_id: str,
 ) -> list[ExplainRecommendation]:
-    # ``daily_plan_id`` lives inside ``payload_json`` (recommendation_log
-    # carries no FK column for it), so we json_extract on lookup. Same
-    # pattern :func:`delete_canonical_plan_cascade` uses on the write side.
+    # M3: ``daily_plan_id`` is now a first-class column with a dedicated
+    # index (``idx_recommendation_log_daily_plan_id``), so this is a
+    # plain B-tree lookup. The column is populated on write and
+    # backfilled for pre-M3 rows by migration 009.
     rows = conn.execute(
         "SELECT recommendation_id, domain, action, confidence, "
         "  bounded, payload_json, issued_at "
         "FROM recommendation_log "
-        "WHERE json_extract(payload_json, '$.daily_plan_id') = ? "
+        "WHERE daily_plan_id = ? "
         "ORDER BY domain, recommendation_id",
         (daily_plan_id,),
     ).fetchall()

--- a/src/health_agent_infra/core/state/migrations/009_recommendation_log_fk.sql
+++ b/src/health_agent_infra/core/state/migrations/009_recommendation_log_fk.sql
@@ -1,0 +1,44 @@
+-- Migration 009 — recommendation_log.daily_plan_id column (M3 of the
+-- post-v0.1.0 hardening plan).
+--
+-- Problem solved. Until now the linkage between ``recommendation_log``
+-- and ``daily_plan`` lived inside the recommendation's ``payload_json``
+-- blob. Readers that needed the join (the explain bundle loader,
+-- the cascade-delete path in ``delete_canonical_plan_cascade``) had to
+-- ``json_extract(payload_json, '$.daily_plan_id')`` on every row — not
+-- indexable, not enforceable, and subtle to grep for.
+--
+-- This migration lifts the id into a proper column + index so the
+-- join is a regular B-tree lookup and the relationship is visible in
+-- the schema rather than hidden inside a JSON string.
+--
+-- SQLite specifics.
+--   - We add the column as nullable. A strict ``NOT NULL`` would
+--     require a default for the backfill UPDATE and would tangle the
+--     legacy ``project_recommendation`` path (writeback) which has no
+--     plan id. Nullable + "set on insert where known, leave NULL
+--     otherwise" keeps the write surface honest.
+--   - We do not retrofit an actual foreign-key constraint. SQLite
+--     cannot add FKs to an existing table in place (it would require
+--     a rebuild-and-rename). The invariant is enforced by the write
+--     path instead: ``project_bounded_recommendation`` and the JSONL
+--     reproject path now pass ``daily_plan_id`` as a kwarg, and
+--     ``delete_canonical_plan_cascade`` reads by column on the way
+--     out. Any future FK retrofit would happen in a dedicated
+--     "rebuild recommendation_log with FK" migration.
+--
+-- Backfill. Every existing recommendation that was synthesised via
+-- ``run_synthesis`` already carries ``daily_plan_id`` inside its
+-- payload; we copy it out. Legacy writeback-produced rows (pre-3
+-- recovery-only path) have no ``daily_plan_id`` in payload and stay
+-- NULL after the backfill — which is correct, they belong to no plan.
+
+ALTER TABLE recommendation_log
+  ADD COLUMN daily_plan_id TEXT;
+
+UPDATE recommendation_log
+   SET daily_plan_id = json_extract(payload_json, '$.daily_plan_id')
+ WHERE daily_plan_id IS NULL;
+
+CREATE INDEX idx_recommendation_log_daily_plan_id
+  ON recommendation_log(daily_plan_id);

--- a/src/health_agent_infra/core/state/projector.py
+++ b/src/health_agent_infra/core/state/projector.py
@@ -1154,8 +1154,9 @@ def reproject_from_jsonl(conn: sqlite3.Connection, base_dir, *, allow_empty: boo
                         recommendation_id, user_id, for_date, issued_at,
                         action, confidence, bounded, payload_json,
                         jsonl_offset, source, ingest_actor, agent_version,
-                        produced_at, validated_at, projected_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        produced_at, validated_at, projected_at,
+                        daily_plan_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         data["recommendation_id"],
@@ -1173,6 +1174,11 @@ def reproject_from_jsonl(conn: sqlite3.Connection, base_dir, *, allow_empty: boo
                         data.get("produced_at", data["issued_at"]),
                         data.get("validated_at", _now_iso()),
                         _now_iso(),
+                        # JSONL rows predating M3 simply won't carry a
+                        # daily_plan_id; .get returns None and the
+                        # column stays NULL, matching the backfill's
+                        # pre-M3 semantics.
+                        data.get("daily_plan_id"),
                     ),
                 )
                 counts["recommendations"] += 1
@@ -1654,14 +1660,19 @@ def project_bounded_recommendation(
     ``recommendation_id`` is a programming error.
     """
 
+    # M3: ``daily_plan_id`` is now a first-class column. The linkage
+    # still lives in payload_json for audit completeness (and for the
+    # JSONL reproject path that doesn't have the column at parse time
+    # in older logs), but the column is the queryable join key.
     conn.execute(
         """
         INSERT INTO recommendation_log (
             recommendation_id, user_id, for_date, issued_at,
             action, confidence, bounded, payload_json,
             jsonl_offset, source, ingest_actor, agent_version,
-            produced_at, validated_at, projected_at, domain
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            produced_at, validated_at, projected_at, domain,
+            daily_plan_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             recommendation["recommendation_id"],
@@ -1680,6 +1691,7 @@ def project_bounded_recommendation(
             _now_iso(),
             _now_iso(),
             recommendation.get("domain", "recovery"),
+            recommendation.get("daily_plan_id"),
         ),
     )
     if commit_after:
@@ -1705,12 +1717,13 @@ def delete_canonical_plan_cascade(
     the whole replacement lands or nothing changes.
     """
 
-    # Every recommendation we wrote for this plan has daily_plan_id baked
-    # into its payload_json. We stored the linkage there; now reverse it
-    # by pulling the ids out of the JSON blob.
+    # M3: every recommendation for this plan carries daily_plan_id as a
+    # proper column (migration 009). Pre-M3 rows were backfilled from
+    # payload_json at migration time, so the column lookup finds every
+    # row the previous json_extract path did.
     rec_rows = conn.execute(
-        "SELECT recommendation_id, payload_json FROM recommendation_log "
-        "WHERE json_extract(payload_json, '$.daily_plan_id') = ?",
+        "SELECT recommendation_id FROM recommendation_log "
+        "WHERE daily_plan_id = ?",
         (daily_plan_id,),
     ).fetchall()
     for row in rec_rows:


### PR DESCRIPTION
## Summary
- Migration 009 promotes `daily_plan_id` from a payload_json blob field to a first-class nullable column on `recommendation_log`, backfilled from `json_extract(payload_json, '$.daily_plan_id')` on existing rows, with `idx_recommendation_log_daily_plan_id` covering the natural lookup.
- `project_bounded_recommendation` and the JSONL reproject path now write the column; `_load_recommendations_for_plan` (explain loader) and `delete_canonical_plan_cascade` both swap `json_extract(...)` predicates for direct column lookups.
- SQLite can't retrofit a proper FK in place; the relationship is enforced on the write path instead. Legacy writeback rows (pre-synthesis recovery-only) stay NULL after backfill — the column is intentionally sparse, not invented.

## Test plan
- [x] `uv run pytest safety/tests -q` — 1359 passing after rebase on main-with-M2
- [x] `test_migration_009.py` covers column shape, index, EXPLAIN uses the index, backfill correctness, legacy-row NULL retention, writer-side column population
- [x] Smoke: `run_synthesis` writes the column; `hai explain` reconstructs bundles via the new lookup path