### PR TITLE
M4: review_outcome enrichment columns + CLI flags + aggregate tier

### DIFF
--- a/safety/tests/test_review_outcome_enriched.py
+++ b/safety/tests/test_review_outcome_enriched.py
@@ -1,0 +1,445 @@
+"""M4 — review_outcome enrichment fields.
+
+Contracts pinned:
+
+  1. Legacy callers (no enriched kwargs) land rows with NULL on every
+     new column; existing behavior is unchanged.
+  2. ``record_review_outcome`` round-trips each enriched kwarg through
+     the dataclass into the JSONL and DB projection.
+  3. ``disagreed_firing_ids`` serializes as a JSON-encoded list in the
+     DB column; NULL and empty-list are distinguishable
+     ("not asked" vs "asked, no disagreement").
+  4. ``summarize_review_history`` emits no ``enriched`` key when every
+     outcome is legacy-shaped, and emits populated aggregates only when
+     outcomes contribute to each respective count.
+  5. The CLI's ``hai review record`` flags take precedence over the
+     same keys in ``--outcome-json`` when both are present.
+  6. Migration 010 adds the six columns as nullable.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from health_agent_infra.cli import main as cli_main
+from health_agent_infra.core.review.outcomes import (
+    INTENSITY_DELTA_ORDINAL,
+    record_review_outcome,
+    summarize_review_history,
+)
+from health_agent_infra.core.schemas import (
+    ReviewEvent,
+    ReviewOutcome,
+)
+from health_agent_infra.core.state import (
+    initialize_database,
+    open_connection,
+    project_review_event,
+    project_review_outcome,
+)
+
+
+AS_OF = date(2026, 4, 17)
+REVIEW_AT = datetime(2026, 4, 18, 7, 0, tzinfo=timezone.utc)
+RECORDED_AT = datetime(2026, 4, 18, 19, 0, tzinfo=timezone.utc)
+
+
+def _init_db(tmp_path: Path) -> Path:
+    db = tmp_path / "state.db"
+    initialize_database(db)
+    return db
+
+
+def _event(event_id: str = "rev_1", rec_id: str = "rec_1") -> ReviewEvent:
+    return ReviewEvent(
+        review_event_id=event_id,
+        recommendation_id=rec_id,
+        user_id="u_test",
+        review_at=REVIEW_AT,
+        review_question="Did the session feel appropriate?",
+        domain="running",
+    )
+
+
+def _seed_event_and_fake_rec(conn: sqlite3.Connection, event: ReviewEvent) -> None:
+    """Seed the recommendation_log + review_event rows the outcome FKs need.
+
+    ReviewOutcome references both via FK, so the DB projection tests
+    need a row in each upstream table.
+    """
+
+    conn.execute(
+        """
+        INSERT INTO recommendation_log (
+            recommendation_id, user_id, for_date, issued_at,
+            action, confidence, bounded, payload_json,
+            jsonl_offset, source, ingest_actor, agent_version,
+            produced_at, validated_at, projected_at, domain
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            event.recommendation_id, event.user_id, AS_OF.isoformat(),
+            REVIEW_AT.isoformat(), "proceed_with_planned_run", "high", 1,
+            "{}", None, "claude_agent_v1", "claude_agent_v1", None,
+            REVIEW_AT.isoformat(), REVIEW_AT.isoformat(),
+            REVIEW_AT.isoformat(), "running",
+        ),
+    )
+    project_review_event(conn, event)
+
+
+# ---------------------------------------------------------------------------
+# Migration shape
+# ---------------------------------------------------------------------------
+
+
+def test_migration_010_adds_six_nullable_columns(tmp_path: Path):
+    db = _init_db(tmp_path)
+    conn = open_connection(db)
+    try:
+        rows = conn.execute("PRAGMA table_info(review_outcome)").fetchall()
+        cols = {r["name"]: dict(r) for r in rows}
+    finally:
+        conn.close()
+
+    for name in (
+        "completed",
+        "intensity_delta",
+        "duration_minutes",
+        "pre_energy_score",
+        "post_energy_score",
+        "disagreed_firing_ids",
+    ):
+        assert name in cols, f"migration 010 did not add {name}"
+        assert cols[name]["notnull"] == 0, f"{name} must be nullable"
+
+
+# ---------------------------------------------------------------------------
+# Legacy-shape round trip — NULLs on every new column
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_callers_land_nulls_on_enriched_columns(tmp_path: Path):
+    db = _init_db(tmp_path)
+    event = _event()
+    conn = open_connection(db)
+    try:
+        _seed_event_and_fake_rec(conn, event)
+    finally:
+        conn.close()
+
+    outcome = record_review_outcome(
+        event,
+        base_dir=tmp_path,
+        followed_recommendation=True,
+        self_reported_improvement=True,
+        now=RECORDED_AT,
+    )
+    conn = open_connection(db)
+    try:
+        project_review_outcome(conn, outcome)
+        row = conn.execute(
+            "SELECT completed, intensity_delta, duration_minutes, "
+            "pre_energy_score, post_energy_score, disagreed_firing_ids "
+            "FROM review_outcome WHERE review_event_id = ?",
+            (event.review_event_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row["completed"] is None
+    assert row["intensity_delta"] is None
+    assert row["duration_minutes"] is None
+    assert row["pre_energy_score"] is None
+    assert row["post_energy_score"] is None
+    assert row["disagreed_firing_ids"] is None
+
+
+# ---------------------------------------------------------------------------
+# Full enriched round trip
+# ---------------------------------------------------------------------------
+
+
+def test_enriched_round_trip_through_jsonl_and_db(tmp_path: Path):
+    db = _init_db(tmp_path)
+    event = _event()
+    conn = open_connection(db)
+    try:
+        _seed_event_and_fake_rec(conn, event)
+    finally:
+        conn.close()
+
+    outcome = record_review_outcome(
+        event,
+        base_dir=tmp_path,
+        followed_recommendation=True,
+        self_reported_improvement=True,
+        free_text="felt great",
+        now=RECORDED_AT,
+        completed=True,
+        intensity_delta="harder",
+        duration_minutes=52,
+        pre_energy_score=3,
+        post_energy_score=4,
+        disagreed_firing_ids=["12", "18"],
+    )
+
+    jsonl_line = (tmp_path / "review_outcomes.jsonl").read_text().strip()
+    payload = json.loads(jsonl_line)
+    assert payload["completed"] is True
+    assert payload["intensity_delta"] == "harder"
+    assert payload["duration_minutes"] == 52
+    assert payload["pre_energy_score"] == 3
+    assert payload["post_energy_score"] == 4
+    assert payload["disagreed_firing_ids"] == ["12", "18"]
+
+    conn = open_connection(db)
+    try:
+        project_review_outcome(conn, outcome)
+        row = conn.execute(
+            "SELECT completed, intensity_delta, duration_minutes, "
+            "pre_energy_score, post_energy_score, disagreed_firing_ids "
+            "FROM review_outcome WHERE review_event_id = ?",
+            (event.review_event_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row["completed"] == 1
+    assert row["intensity_delta"] == "harder"
+    assert row["duration_minutes"] == 52
+    assert row["pre_energy_score"] == 3
+    assert row["post_energy_score"] == 4
+    # disagreed_firing_ids is JSON-encoded in TEXT so a future reader
+    # can parse back to the list shape.
+    assert json.loads(row["disagreed_firing_ids"]) == ["12", "18"]
+
+
+def test_empty_disagreed_list_distinguishes_from_null(tmp_path: Path):
+    """`disagreed_firing_ids = []` means 'asked, no disagreement'. NULL
+    means 'question was not asked'. Both must land distinctly."""
+
+    db = _init_db(tmp_path)
+    event_a = _event(event_id="rev_a", rec_id="rec_a")
+    event_b = _event(event_id="rev_b", rec_id="rec_b")
+    conn = open_connection(db)
+    try:
+        _seed_event_and_fake_rec(conn, event_a)
+        _seed_event_and_fake_rec(conn, event_b)
+    finally:
+        conn.close()
+
+    a = record_review_outcome(
+        event_a, base_dir=tmp_path,
+        followed_recommendation=True, self_reported_improvement=True,
+        now=RECORDED_AT, disagreed_firing_ids=[],
+    )
+    b = record_review_outcome(
+        event_b, base_dir=tmp_path,
+        followed_recommendation=True, self_reported_improvement=True,
+        now=RECORDED_AT,
+    )
+
+    conn = open_connection(db)
+    try:
+        project_review_outcome(conn, a)
+        project_review_outcome(conn, b)
+        row_a = conn.execute(
+            "SELECT disagreed_firing_ids FROM review_outcome "
+            "WHERE review_event_id = ?", (event_a.review_event_id,),
+        ).fetchone()
+        row_b = conn.execute(
+            "SELECT disagreed_firing_ids FROM review_outcome "
+            "WHERE review_event_id = ?", (event_b.review_event_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row_a["disagreed_firing_ids"] == "[]"
+    assert row_b["disagreed_firing_ids"] is None
+
+
+# ---------------------------------------------------------------------------
+# summarize_review_history — enriched aggregates
+# ---------------------------------------------------------------------------
+
+
+def _outcome(**overrides) -> ReviewOutcome:
+    base = dict(
+        review_event_id="rev_1",
+        recommendation_id="rec_1",
+        user_id="u_test",
+        recorded_at=RECORDED_AT,
+        followed_recommendation=True,
+        self_reported_improvement=True,
+        free_text=None,
+        domain="running",
+    )
+    base.update(overrides)
+    return ReviewOutcome(**base)
+
+
+def test_summary_omits_enriched_on_legacy_only_outcomes():
+    outcomes = [
+        _outcome(),
+        _outcome(followed_recommendation=False, self_reported_improvement=None),
+    ]
+    summary = summarize_review_history(outcomes)
+    assert "enriched" not in summary
+    assert summary["total"] == 2
+
+
+def test_summary_populates_enriched_when_any_outcome_carries_enrichment():
+    outcomes = [
+        _outcome(completed=True, intensity_delta="harder",
+                 pre_energy_score=3, post_energy_score=4),
+        _outcome(completed=False, intensity_delta="same",
+                 pre_energy_score=4, post_energy_score=3),
+        _outcome(completed=True),  # only completion, no intensity/energy
+        _outcome(),  # legacy-only
+    ]
+    summary = summarize_review_history(outcomes)
+
+    assert summary["total"] == 4
+    enriched = summary["enriched"]
+
+    assert enriched["completion_count"] == 3
+    # 2 completed out of 3 → 2/3
+    assert enriched["completion_rate"] == pytest.approx(2 / 3)
+
+    assert enriched["intensity_delta_count"] == 2
+    # harder + same → 1 + 0 → mean 0.5
+    assert enriched["mean_intensity_delta"] == pytest.approx(
+        (INTENSITY_DELTA_ORDINAL["harder"] + INTENSITY_DELTA_ORDINAL["same"]) / 2
+    )
+
+    assert enriched["energy_delta_count"] == 2
+    # (4-3) + (3-4) / 2 = 0
+    assert enriched["mean_energy_delta"] == pytest.approx(0.0)
+
+
+def test_summary_emits_enriched_with_none_values_when_only_duration_is_set():
+    """A single outcome recording only duration_minutes still activates
+    the enriched block — but every per-field count is zero and the
+    mean is None. This keeps 'I recorded something' and 'I recorded
+    nothing' distinguishable without forcing the consumer to probe
+    every optional field."""
+
+    summary = summarize_review_history([_outcome(duration_minutes=45)])
+    assert "enriched" in summary
+    assert summary["enriched"]["completion_rate"] is None
+    assert summary["enriched"]["mean_intensity_delta"] is None
+    assert summary["enriched"]["mean_energy_delta"] is None
+
+
+def test_summary_skips_unrecognised_intensity_delta_strings():
+    """Unknown labels contribute to neither the mean nor the count —
+    they are tracked as data we don't know how to ordinalise."""
+
+    outcomes = [
+        _outcome(intensity_delta="harder"),
+        _outcome(intensity_delta="wibble"),
+    ]
+    summary = summarize_review_history(outcomes)
+    assert summary["enriched"]["intensity_delta_count"] == 1
+    assert summary["enriched"]["mean_intensity_delta"] == pytest.approx(
+        INTENSITY_DELTA_ORDINAL["harder"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI — flags override --outcome-json keys
+# ---------------------------------------------------------------------------
+
+
+def test_cli_review_record_flags_override_json(tmp_path: Path, capsys):
+    db = _init_db(tmp_path)
+    base_dir = tmp_path / "review_base"
+    base_dir.mkdir()
+
+    event = _event()
+    conn = open_connection(db)
+    try:
+        _seed_event_and_fake_rec(conn, event)
+    finally:
+        conn.close()
+
+    outcome_json = base_dir / "outcome.json"
+    outcome_json.write_text(json.dumps({
+        "review_event_id": event.review_event_id,
+        "recommendation_id": event.recommendation_id,
+        "user_id": event.user_id,
+        "review_at": event.review_at.isoformat(),
+        "review_question": event.review_question,
+        "domain": event.domain,
+        "followed_recommendation": True,
+        "self_reported_improvement": True,
+        "recorded_at": RECORDED_AT.isoformat(),
+        # JSON supplies intensity_delta=same; CLI flag below should win.
+        "intensity_delta": "same",
+        "duration_minutes": 30,
+    }))
+
+    rc = cli_main([
+        "review", "record",
+        "--outcome-json", str(outcome_json),
+        "--base-dir", str(base_dir),
+        "--db-path", str(db),
+        "--intensity-delta", "harder",
+        "--completed", "yes",
+        "--pre-energy", "2",
+        "--post-energy", "4",
+        "--disagreed-firings", "101,102",
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["intensity_delta"] == "harder"    # flag overrode JSON
+    assert payload["duration_minutes"] == 30         # JSON pass-through
+    assert payload["completed"] is True
+    assert payload["pre_energy_score"] == 2
+    assert payload["post_energy_score"] == 4
+    assert payload["disagreed_firing_ids"] == ["101", "102"]
+
+
+def test_cli_review_record_disagreed_firings_empty_string_records_empty_list(
+    tmp_path: Path, capsys,
+):
+    db = _init_db(tmp_path)
+    base_dir = tmp_path / "review_base"
+    base_dir.mkdir()
+
+    event = _event()
+    conn = open_connection(db)
+    try:
+        _seed_event_and_fake_rec(conn, event)
+    finally:
+        conn.close()
+
+    outcome_json = base_dir / "outcome.json"
+    outcome_json.write_text(json.dumps({
+        "review_event_id": event.review_event_id,
+        "recommendation_id": event.recommendation_id,
+        "user_id": event.user_id,
+        "review_at": event.review_at.isoformat(),
+        "review_question": event.review_question,
+        "domain": event.domain,
+        "followed_recommendation": True,
+        "self_reported_improvement": True,
+        "recorded_at": RECORDED_AT.isoformat(),
+    }))
+
+    rc = cli_main([
+        "review", "record",
+        "--outcome-json", str(outcome_json),
+        "--base-dir", str(base_dir),
+        "--db-path", str(db),
+        "--disagreed-firings", "",
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["disagreed_firing_ids"] == []

--- a/safety/tests/test_state_store.py
+++ b/safety/tests/test_state_store.py
@@ -111,6 +111,7 @@ def test_schema_migrations_has_one_row_per_applied_migration(tmp_path: Path):
         (7, "007_user_memory.sql"),
         (8, "008_sync_run_log.sql"),
         (9, "009_recommendation_log_fk.sql"),
+        (10, "010_review_outcome_enrichment.sql"),
     ]
 
 
@@ -126,7 +127,7 @@ def test_schema_migrations_not_duplicated_on_repeat_init(tmp_path: Path):
     finally:
         conn.close()
 
-    assert count == 9
+    assert count == 10
 
 
 def test_current_schema_version_zero_on_empty_db(tmp_path: Path):
@@ -144,7 +145,7 @@ def test_current_schema_version_matches_head_after_init(tmp_path: Path):
 
     conn = open_connection(db_path)
     try:
-        assert current_schema_version(conn) == 9
+        assert current_schema_version(conn) == 10
     finally:
         conn.close()
 
@@ -283,8 +284,8 @@ def test_cli_state_migrate_on_head_db_reports_empty_applied(tmp_path: Path, caps
 
     import json
     payload = json.loads(capsys.readouterr().out)
-    assert payload["schema_version_before"] == 9
-    assert payload["schema_version_after"] == 9
+    assert payload["schema_version_before"] == 10
+    assert payload["schema_version_after"] == 10
     assert payload["applied"] == []
 
 
@@ -355,7 +356,7 @@ def test_broken_migration_rolls_back_ddl_and_bookkeeping(tmp_path: Path):
         assert len(rows) == 1
 
         # Version is still at head (pre-broken migration), not 99.
-        assert current_schema_version(conn) == 9
+        assert current_schema_version(conn) == 10
     finally:
         conn.close()
 

--- a/src/health_agent_infra/cli.py
+++ b/src/health_agent_infra/cli.py
@@ -1253,6 +1253,50 @@ def cmd_review_record(args: argparse.Namespace) -> int:
         review_question=data.get("review_question", ""),
         domain=domain,
     )
+
+    # M4 enrichment: CLI flags override the same key in --outcome-json
+    # when both are present. Each resolution is explicit — we never
+    # "merge" lists or coerce types silently.
+    if args.completed is not None:
+        completed_val: Optional[bool] = args.completed == "yes"
+    else:
+        completed_val = data.get("completed")
+
+    intensity_delta = (
+        args.intensity_delta
+        if args.intensity_delta is not None
+        else data.get("intensity_delta")
+    )
+    duration_minutes = (
+        args.duration_minutes
+        if args.duration_minutes is not None
+        else data.get("duration_minutes")
+    )
+    pre_energy_score = (
+        args.pre_energy
+        if args.pre_energy is not None
+        else data.get("pre_energy_score")
+    )
+    post_energy_score = (
+        args.post_energy
+        if args.post_energy is not None
+        else data.get("post_energy_score")
+    )
+
+    if args.disagreed_firings is not None:
+        disagreed_raw = args.disagreed_firings.strip()
+        if disagreed_raw == "":
+            # Explicit empty string = "I was asked and had no disagreements."
+            # NULL in the column would mean "not asked," so preserve the
+            # empty-list distinction.
+            disagreed_firing_ids: Optional[list[str]] = []
+        else:
+            disagreed_firing_ids = [
+                tok.strip() for tok in disagreed_raw.split(",") if tok.strip()
+            ]
+    else:
+        disagreed_firing_ids = data.get("disagreed_firing_ids")
+
     outcome = record_review_outcome(
         event,
         base_dir=Path(args.base_dir),
@@ -1260,6 +1304,12 @@ def cmd_review_record(args: argparse.Namespace) -> int:
         self_reported_improvement=data.get("self_reported_improvement"),
         free_text=data.get("free_text"),
         now=_coerce_dt(data.get("recorded_at")),
+        completed=completed_val,
+        intensity_delta=intensity_delta,
+        duration_minutes=duration_minutes,
+        pre_energy_score=pre_energy_score,
+        post_energy_score=post_energy_score,
+        disagreed_firing_ids=disagreed_firing_ids,
     )
 
     _dual_write_project(
@@ -1294,6 +1344,14 @@ def cmd_review_summary(args: argparse.Namespace) -> int:
             self_reported_improvement=d.get("self_reported_improvement"),
             free_text=d.get("free_text"),
             domain=d.get("domain", "recovery"),
+            # M4 enrichment — pre-M4 JSONL rows don't carry these keys,
+            # .get returns None, dataclass defaults align.
+            completed=d.get("completed"),
+            intensity_delta=d.get("intensity_delta"),
+            duration_minutes=d.get("duration_minutes"),
+            pre_energy_score=d.get("pre_energy_score"),
+            post_energy_score=d.get("post_energy_score"),
+            disagreed_firing_ids=d.get("disagreed_firing_ids"),
         ))
     _emit_json(summarize_review_history(outcomes, domain=domain_filter))
     return 0
@@ -1305,6 +1363,13 @@ def cmd_review_summary(args: argparse.Namespace) -> int:
 
 SORENESS_CHOICES = ("low", "moderate", "high")
 ENERGY_CHOICES = ("low", "moderate", "high")
+# M4 — intensity_delta ordinal axis. Kept here (not inside the review
+# module) so the CLI-facing choices list lives next to other CLI enums.
+# summarize_review_history imports this via the mapping below so there's
+# one source of truth.
+INTENSITY_DELTA_CHOICES = (
+    "much_lighter", "lighter", "same", "harder", "much_harder",
+)
 EXERCISE_CATEGORY_CHOICES = ("compound", "isolation")
 EXERCISE_EQUIPMENT_CHOICES = (
     "barbell", "dumbbell", "cable", "bodyweight", "machine", "kettlebell",
@@ -3447,6 +3512,42 @@ def build_parser() -> argparse.ArgumentParser:
     p_rr.add_argument("--base-dir", required=True)
     p_rr.add_argument("--db-path", default=None,
                       help="State DB path (same semantics as `hai writeback --db-path`)")
+    # M4 enrichment flags. All optional; each overrides the same key in
+    # --outcome-json when both are provided. Omitted flags + JSON-absent
+    # fields land NULL in the DB, which is the pre-M4 shape.
+    p_rr.add_argument(
+        "--completed", choices=("yes", "no"), default=None,
+        help="Whether the user completed the recommended session.",
+    )
+    p_rr.add_argument(
+        "--intensity-delta",
+        choices=INTENSITY_DELTA_CHOICES, default=None,
+        help=(
+            "Intensity the user applied relative to the recommendation. "
+            "Ordinals used by summary aggregation: "
+            "much_lighter=-2, lighter=-1, same=0, harder=1, much_harder=2."
+        ),
+    )
+    p_rr.add_argument(
+        "--duration-minutes", type=int, default=None,
+        help="Actual session duration in whole minutes.",
+    )
+    p_rr.add_argument(
+        "--pre-energy", type=int, choices=range(1, 6), default=None,
+        help="Self-reported energy score before the session, 1–5.",
+    )
+    p_rr.add_argument(
+        "--post-energy", type=int, choices=range(1, 6), default=None,
+        help="Self-reported energy score after the session, 1–5.",
+    )
+    p_rr.add_argument(
+        "--disagreed-firings", default=None,
+        help=(
+            "Comma-separated x_rule_firing.firing_id list the user "
+            "marked as 'should not have fired'. Empty string records an "
+            "explicit empty list (the question was asked, no disagreement)."
+        ),
+    )
     p_rr.set_defaults(func=cmd_review_record)
 
     p_rsum = review_sub.add_parser("summary", help="Summarize outcome history counts")

--- a/src/health_agent_infra/core/review/outcomes.py
+++ b/src/health_agent_infra/core/review/outcomes.py
@@ -84,11 +84,23 @@ def record_review_outcome(
     free_text: Optional[str] = None,
     now: Optional[datetime] = None,
     domain: Optional[str] = None,
+    completed: Optional[bool] = None,
+    intensity_delta: Optional[str] = None,
+    duration_minutes: Optional[int] = None,
+    pre_energy_score: Optional[int] = None,
+    post_energy_score: Optional[int] = None,
+    disagreed_firing_ids: Optional[list[str]] = None,
 ) -> ReviewOutcome:
     """Persist a user-supplied outcome for a previously scheduled review event.
 
     ``domain`` defaults to the event's domain (which itself defaults to
     ``"recovery"``) so outcomes stay aligned with their owning event.
+
+    The M4 enrichment kwargs (``completed`` / ``intensity_delta`` /
+    ``duration_minutes`` / ``pre_energy_score`` / ``post_energy_score`` /
+    ``disagreed_firing_ids``) are all optional. Callers that don't
+    populate them land NULL columns — which is how pre-M4 outcomes
+    always looked, so the expansion is backward-compatible.
     """
 
     now = now or datetime.now(timezone.utc)
@@ -106,6 +118,12 @@ def record_review_outcome(
         self_reported_improvement=self_reported_improvement,
         free_text=free_text,
         domain=resolved_domain,
+        completed=completed,
+        intensity_delta=intensity_delta,
+        duration_minutes=duration_minutes,
+        pre_energy_score=pre_energy_score,
+        post_energy_score=post_energy_score,
+        disagreed_firing_ids=disagreed_firing_ids,
     )
 
     with outcomes_path.open("a", encoding="utf-8") as fh:
@@ -127,11 +145,26 @@ def _event_already_written(path: Path, review_event_id: str) -> bool:
     return False
 
 
+# M4 — intensity_delta ordinal axis. Surfaced alongside the CLI's
+# ``INTENSITY_DELTA_CHOICES`` as a single source of truth for how an
+# ordinal "intensity_delta" string maps to a numeric score. Unknown
+# strings are skipped during aggregation rather than silently treated
+# as zero, because "unrecognised label" and "user reported same
+# intensity" are not the same signal.
+INTENSITY_DELTA_ORDINAL: dict[str, int] = {
+    "much_lighter": -2,
+    "lighter": -1,
+    "same": 0,
+    "harder": 1,
+    "much_harder": 2,
+}
+
+
 def summarize_review_history(
     outcomes: list[ReviewOutcome],
     *,
     domain: Optional[str] = None,
-) -> dict[str, int]:
+) -> dict[str, Any]:
     """Count review outcomes by category. Deterministic bookkeeping, not judgment.
 
     The runtime surfaces structured summary state; the LLM consumer forms
@@ -157,12 +190,32 @@ def summarize_review_history(
     The four non-total keys always sum to ``total``; a consumer can derive
     any rate it wants from these counts without the runtime taking a
     position on which rate matters.
+
+    M4 enrichment aggregates are emitted under the ``enriched`` key
+    **only when at least one outcome in the filtered input populates at
+    least one enriched field**. This keeps the legacy shape intact for
+    callers that only see pre-M4 rows and avoids inventing zero-valued
+    aggregates for samples that were never collected. The ``enriched``
+    dict carries:
+      - ``completion_rate``: fraction of outcomes with ``completed=True``
+        out of outcomes where ``completed`` was recorded. ``None`` when
+        no outcome recorded a completion.
+      - ``completion_count``: count contributing to ``completion_rate``.
+      - ``mean_intensity_delta``: mean of
+        ``INTENSITY_DELTA_ORDINAL[intensity_delta]`` across outcomes
+        whose ``intensity_delta`` is a recognised key. ``None`` when no
+        outcome contributed.
+      - ``intensity_delta_count``: count contributing.
+      - ``mean_energy_delta``: mean of ``post - pre`` across outcomes
+        where both scores are populated. ``None`` when no outcome
+        contributed.
+      - ``energy_delta_count``: count contributing.
     """
 
     if domain is not None:
         outcomes = [o for o in outcomes if o.domain == domain]
 
-    summary = {
+    summary: dict[str, Any] = {
         "total": len(outcomes),
         "followed_improved": 0,
         "followed_no_change": 0,
@@ -181,4 +234,71 @@ def summarize_review_history(
         else:
             summary["followed_unknown"] += 1
 
+    enriched = _enriched_aggregates(outcomes)
+    if enriched is not None:
+        summary["enriched"] = enriched
+
     return summary
+
+
+def _enriched_aggregates(
+    outcomes: list[ReviewOutcome],
+) -> Optional[dict[str, Any]]:
+    """Compute the M4 enriched-tier aggregates, or return ``None``.
+
+    Returns ``None`` when no outcome in ``outcomes`` populates any of the
+    enrichment fields, so the legacy 5-key summary shape is preserved
+    for callers that only see pre-M4 data.
+    """
+
+    completed_values = [
+        o.completed for o in outcomes if o.completed is not None
+    ]
+    intensity_values = [
+        INTENSITY_DELTA_ORDINAL[o.intensity_delta]
+        for o in outcomes
+        if o.intensity_delta in INTENSITY_DELTA_ORDINAL
+    ]
+    energy_deltas = [
+        o.post_energy_score - o.pre_energy_score
+        for o in outcomes
+        if o.pre_energy_score is not None and o.post_energy_score is not None
+    ]
+
+    has_any = (
+        bool(completed_values)
+        or bool(intensity_values)
+        or bool(energy_deltas)
+        or any(
+            o.duration_minutes is not None
+            or o.disagreed_firing_ids is not None
+            for o in outcomes
+        )
+    )
+    if not has_any:
+        return None
+
+    completion_rate = (
+        sum(1 for v in completed_values if v) / len(completed_values)
+        if completed_values
+        else None
+    )
+    mean_intensity_delta = (
+        sum(intensity_values) / len(intensity_values)
+        if intensity_values
+        else None
+    )
+    mean_energy_delta = (
+        sum(energy_deltas) / len(energy_deltas)
+        if energy_deltas
+        else None
+    )
+
+    return {
+        "completion_rate": completion_rate,
+        "completion_count": len(completed_values),
+        "mean_intensity_delta": mean_intensity_delta,
+        "intensity_delta_count": len(intensity_values),
+        "mean_energy_delta": mean_energy_delta,
+        "energy_delta_count": len(energy_deltas),
+    }

--- a/src/health_agent_infra/core/schemas.py
+++ b/src/health_agent_infra/core/schemas.py
@@ -342,6 +342,14 @@ class ReviewOutcome:
     self_reported_improvement: Optional[bool]
     free_text: Optional[str] = None
     domain: str = "recovery"
+    # M4 enrichment — every field is optional. Legacy outcomes and
+    # callers that don't populate these stay unaffected.
+    completed: Optional[bool] = None
+    intensity_delta: Optional[str] = None
+    duration_minutes: Optional[int] = None
+    pre_energy_score: Optional[int] = None
+    post_energy_score: Optional[int] = None
+    disagreed_firing_ids: Optional[list[str]] = None
 
     def to_dict(self) -> dict:
         return {
@@ -353,4 +361,14 @@ class ReviewOutcome:
             "self_reported_improvement": self.self_reported_improvement,
             "free_text": self.free_text,
             "domain": self.domain,
+            "completed": self.completed,
+            "intensity_delta": self.intensity_delta,
+            "duration_minutes": self.duration_minutes,
+            "pre_energy_score": self.pre_energy_score,
+            "post_energy_score": self.post_energy_score,
+            "disagreed_firing_ids": (
+                list(self.disagreed_firing_ids)
+                if self.disagreed_firing_ids is not None
+                else None
+            ),
         }

--- a/src/health_agent_infra/core/state/migrations/010_review_outcome_enrichment.sql
+++ b/src/health_agent_infra/core/state/migrations/010_review_outcome_enrichment.sql
@@ -1,0 +1,47 @@
+-- Migration 010 — review_outcome enrichment (M4 of the post-v0.1.0
+-- hardening plan).
+--
+-- Adds six optional columns that widen the signal captured on a
+-- review outcome. Every column is nullable by design: legacy outcomes
+-- (pre-010) carry NULLs, and callers that want only the original
+-- yes/no-improved shape stay working without touching anything.
+--
+-- The shape is intentionally conservative for v1 — it captures what a
+-- future learning loop (deliberately deferred per non_goals.md) would
+-- need without baking in the learning algorithm itself:
+--
+--   - ``completed`` — did the user finish the recommended session at
+--     all. Distinct from ``followed_recommendation`` which asks
+--     "did you do what we suggested" (including any modifications).
+--     0 = did not complete, 1 = completed, NULL = not recorded.
+--
+--   - ``intensity_delta`` — relative intensity the user applied vs
+--     the recommendation. TEXT because v1 consumers gather ordinal
+--     strings (lighter/same/harder) rather than a continuous value;
+--     aggregation maps known strings to ordinals.
+--
+--   - ``duration_minutes`` — actual session length. Nullable so
+--     non-training reviews (e.g. stress check-ins, sleep reviews)
+--     don't need to invent a value.
+--
+--   - ``pre_energy_score`` / ``post_energy_score`` — self-reported
+--     energy on a 1–5 scale before and after the session. The delta
+--     (post - pre) is the signal an aggregation reports.
+--
+--   - ``disagreed_firing_ids`` — JSON array of x_rule_firing.firing_id
+--     the user marked as "I don't think this rule should have fired."
+--     Stored as TEXT (JSON-encoded) to keep it flexible without a
+--     second table. Empty array = no disagreements logged; NULL =
+--     the disagreement question was not asked.
+--
+-- No indexes added. These columns are not hot-path join keys — they
+-- are read in bulk by ``summarize_review_history`` and occasionally
+-- per-outcome by the explain surface. A future index lands only if
+-- a concrete query shape demands it.
+
+ALTER TABLE review_outcome ADD COLUMN completed             INTEGER;
+ALTER TABLE review_outcome ADD COLUMN intensity_delta       TEXT;
+ALTER TABLE review_outcome ADD COLUMN duration_minutes      INTEGER;
+ALTER TABLE review_outcome ADD COLUMN pre_energy_score      INTEGER;
+ALTER TABLE review_outcome ADD COLUMN post_energy_score     INTEGER;
+ALTER TABLE review_outcome ADD COLUMN disagreed_firing_ids  TEXT;

--- a/src/health_agent_infra/core/state/projector.py
+++ b/src/health_agent_infra/core/state/projector.py
@@ -243,13 +243,24 @@ def project_review_outcome(
     appends unconditionally; rely on the source JSONL being canonical.
     """
 
+    # M4 enrichment columns (migration 010). Every field is optional;
+    # NULL means "not recorded" rather than any semantic default.
+    # disagreed_firing_ids is JSON-encoded on write so the column can
+    # stay a simple TEXT without a dedicated join table.
+    disagreed_json = (
+        json.dumps(list(outcome.disagreed_firing_ids))
+        if outcome.disagreed_firing_ids is not None
+        else None
+    )
     cursor = conn.execute(
         """
         INSERT INTO review_outcome (
             review_event_id, recommendation_id, user_id, recorded_at,
             followed_recommendation, self_reported_improvement, free_text,
-            domain, jsonl_offset, source, ingest_actor, projected_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            domain, jsonl_offset, source, ingest_actor, projected_at,
+            completed, intensity_delta, duration_minutes,
+            pre_energy_score, post_energy_score, disagreed_firing_ids
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             outcome.review_event_id,
@@ -264,6 +275,12 @@ def project_review_outcome(
             source,
             ingest_actor,
             _now_iso(),
+            _opt_bool_to_int(outcome.completed),
+            outcome.intensity_delta,
+            outcome.duration_minutes,
+            outcome.pre_energy_score,
+            outcome.post_energy_score,
+            disagreed_json,
         ),
     )
     conn.commit()


### PR DESCRIPTION
## Summary
- Migration 010 adds six nullable columns to `review_outcome`: `completed`, `intensity_delta` (TEXT), `duration_minutes`, `pre_energy_score`, `post_energy_score`, `disagreed_firing_ids` (JSON-encoded list).
- Python: `ReviewOutcome` gains the six optional fields; `record_review_outcome` takes them as kwargs; `project_review_outcome` writes them. `disagreed_firing_ids` preserves the NULL-vs-empty-list distinction ("not asked" vs "asked, no disagreement").
- CLI: `hai review record` gains six optional flags overriding the same keys in `--outcome-json` when both are supplied.
- `summarize_review_history` emits a new `enriched` sub-block — only when at least one outcome populates any enriched field — with `completion_rate`, `mean_intensity_delta` (via `INTENSITY_DELTA_ORDINAL`), and `mean_energy_delta`. Legacy histories keep the byte-identical 5-key shape.

## Test plan
- [x] `uv run pytest safety/tests -q` — 1369 passing after rebase on main-with-M3
- [x] `test_review_outcome_enriched.py` covers migration shape, legacy NULL round-trip, full enriched round-trip, NULL-vs-empty-list, aggregate absence/presence, unrecognised intensity-delta skipping, CLI flag-overrides-JSON
- [x] Smoke: CLI populates every new column; summary returns enriched block with correct means