### PR TITLE
M5: hai doctor consolidation — freshness + today counts + text default

### DIFF
--- a/safety/tests/test_cli_doctor.py
+++ b/safety/tests/test_cli_doctor.py
@@ -1,0 +1,290 @@
+"""M5 — hai doctor consolidation.
+
+Pins the M5-added checks (sync-source freshness + today counts + DB
+size) and the new output format toggle (``--json`` vs human text).
+Tests for the pre-M5 doctor behavior (config / state_db / auth_garmin
+/ skills / domains) live in ``test_cli_init_doctor.py`` — this file
+only covers what M5 added.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from health_agent_infra import cli as cli_mod
+from health_agent_infra.cli import main as cli_main
+from health_agent_infra.core.pull.auth import CredentialStore
+from health_agent_infra.core.state import (
+    initialize_database,
+    open_connection,
+    project_proposal,
+    project_review_event,
+    project_review_outcome,
+)
+from health_agent_infra.core.schemas import (
+    ReviewEvent,
+    ReviewOutcome,
+)
+
+
+class _FakeKeyring:
+    def __init__(self):
+        self._data: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service, username):
+        return self._data.get((service, username))
+
+    def set_password(self, service, username, password):
+        self._data[(service, username)] = password
+
+    def delete_password(self, service, username):
+        self._data.pop((service, username), None)
+
+
+@pytest.fixture
+def fake_store(monkeypatch):
+    store = CredentialStore(backend=_FakeKeyring(), env={})
+    monkeypatch.setattr(
+        cli_mod.CredentialStore, "default", classmethod(lambda cls: store),
+    )
+    return store
+
+
+def _doctor_argv(tmp_path: Path, *extra: str, json_output: bool = True) -> list[str]:
+    argv = ["doctor"]
+    if json_output:
+        argv.append("--json")
+    argv += [
+        "--thresholds-path", str(tmp_path / "thresholds.toml"),
+        "--db-path", str(tmp_path / "state.db"),
+        "--skills-dest", str(tmp_path / "skills"),
+    ]
+    argv += list(extra)
+    return argv
+
+
+def _init_db_at(tmp_path: Path) -> Path:
+    db = tmp_path / "state.db"
+    initialize_database(db)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# sources freshness block
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_sources_block_empty_on_fresh_db(tmp_path, capsys, fake_store):
+    _init_db_at(tmp_path)
+    rc = cli_main(_doctor_argv(tmp_path, "--user-id", "u_test"))
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    sources = report["checks"]["sources"]
+    assert sources["status"] == "ok"
+    assert sources["sources"] == {}
+
+
+def test_doctor_sources_block_reports_freshness_per_source(
+    tmp_path, capsys, fake_store,
+):
+    db = _init_db_at(tmp_path)
+    as_of = date(2026, 4, 17)
+
+    conn = open_connection(db)
+    try:
+        conn.executemany(
+            "INSERT INTO sync_run_log "
+            "(source, user_id, mode, started_at, completed_at, status, "
+            " rows_pulled, rows_accepted, duplicates_skipped) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("garmin", "u_test", "csv",
+                 "2026-04-17T06:00:00+00:00", "2026-04-17T06:00:00+00:00",
+                 "ok", 1, 1, 0),
+                # A failed run must not surface.
+                ("garmin", "u_test", "csv",
+                 "2026-04-17T10:00:00+00:00", "2026-04-17T10:00:02+00:00",
+                 "failed", None, None, None),
+                ("nutrition_manual", "u_test", "manual",
+                 "2026-04-17T20:00:00+00:00", "2026-04-17T20:00:00+00:00",
+                 "ok", 1, 1, 0),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    rc = cli_main(_doctor_argv(
+        tmp_path, "--user-id", "u_test", "--as-of", as_of.isoformat(),
+    ))
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    sources = report["checks"]["sources"]["sources"]
+
+    # Anchor = 2026-04-18 00:00 UTC. garmin @ 06:00 → 18h, nutrition @ 20:00 → 4h.
+    assert set(sources.keys()) == {"garmin", "nutrition_manual"}
+    assert sources["garmin"]["staleness_hours"] == 18.0
+    assert sources["nutrition_manual"]["staleness_hours"] == 4.0
+
+
+# ---------------------------------------------------------------------------
+# today counts
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_today_counts_zero_on_empty_db(tmp_path, capsys, fake_store):
+    _init_db_at(tmp_path)
+    rc = cli_main(_doctor_argv(
+        tmp_path, "--user-id", "u_test", "--as-of", "2026-04-17",
+    ))
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    today = report["checks"]["today"]
+    assert today["status"] == "ok"
+    assert today["for_date"] == "2026-04-17"
+    assert today["user_id"] == "u_test"
+    assert today["proposals"] == 0
+    assert today["recommendations"] == 0
+    assert today["pending_reviews"] == 0
+
+
+def test_doctor_today_counts_reflect_seeded_state(tmp_path, capsys, fake_store):
+    """Seed one proposal, one recommendation, one unresolved review event,
+    and one resolved review event. pending_reviews should be 1."""
+
+    db = _init_db_at(tmp_path)
+    as_of = "2026-04-17"
+    review_at = datetime(2026, 4, 17, 8, tzinfo=timezone.utc)
+    recorded_at = datetime(2026, 4, 17, 20, tzinfo=timezone.utc)
+
+    proposal = {
+        "schema_version": "domain_proposal.v1",
+        "proposal_id": "prop_2026-04-17_u_test_recovery_01",
+        "user_id": "u_test",
+        "for_date": as_of,
+        "domain": "recovery",
+        "action": "proceed_with_planned_session",
+        "action_detail": None,
+        "rationale": ["x"],
+        "confidence": "high",
+        "uncertainty": [],
+        "policy_decisions": [{"rule_id": "r1", "decision": "allow", "note": "ok"}],
+        "bounded": True,
+    }
+
+    conn = open_connection(db)
+    try:
+        project_proposal(conn, proposal)
+        # One recommendation (no daily_plan_id needed for count).
+        conn.execute(
+            "INSERT INTO recommendation_log ("
+            "recommendation_id, user_id, for_date, issued_at, action, "
+            "confidence, bounded, payload_json, jsonl_offset, source, "
+            "ingest_actor, agent_version, produced_at, validated_at, "
+            "projected_at, domain) VALUES "
+            "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            ("rec_a", "u_test", as_of, review_at.isoformat(),
+             "proceed_with_planned_session", "high", 1, "{}", None,
+             "manual", "manual", None, review_at.isoformat(),
+             review_at.isoformat(), review_at.isoformat(), "recovery"),
+        )
+        # Second recommendation for the resolved review.
+        conn.execute(
+            "INSERT INTO recommendation_log ("
+            "recommendation_id, user_id, for_date, issued_at, action, "
+            "confidence, bounded, payload_json, jsonl_offset, source, "
+            "ingest_actor, agent_version, produced_at, validated_at, "
+            "projected_at, domain) VALUES "
+            "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            ("rec_b", "u_test", as_of, review_at.isoformat(),
+             "proceed_with_planned_session", "high", 1, "{}", None,
+             "manual", "manual", None, review_at.isoformat(),
+             review_at.isoformat(), review_at.isoformat(), "recovery"),
+        )
+        pending_event = ReviewEvent(
+            review_event_id="rev_pending",
+            recommendation_id="rec_a",
+            user_id="u_test",
+            review_at=review_at,
+            review_question="How did it feel?",
+            domain="recovery",
+        )
+        resolved_event = ReviewEvent(
+            review_event_id="rev_resolved",
+            recommendation_id="rec_b",
+            user_id="u_test",
+            review_at=review_at,
+            review_question="How did it feel?",
+            domain="recovery",
+        )
+        project_review_event(conn, pending_event)
+        project_review_event(conn, resolved_event)
+        project_review_outcome(conn, ReviewOutcome(
+            review_event_id="rev_resolved",
+            recommendation_id="rec_b",
+            user_id="u_test",
+            recorded_at=recorded_at,
+            followed_recommendation=True,
+            self_reported_improvement=True,
+            free_text=None,
+            domain="recovery",
+        ))
+        conn.commit()
+    finally:
+        conn.close()
+
+    rc = cli_main(_doctor_argv(
+        tmp_path, "--user-id", "u_test", "--as-of", as_of,
+    ))
+    assert rc == 0
+    today = json.loads(capsys.readouterr().out)["checks"]["today"]
+    assert today["proposals"] == 1
+    assert today["recommendations"] == 2
+    # rev_pending has no outcome; rev_resolved does → exactly one pending.
+    assert today["pending_reviews"] == 1
+
+
+# ---------------------------------------------------------------------------
+# DB size
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_state_db_includes_size_bytes(tmp_path, capsys, fake_store):
+    _init_db_at(tmp_path)
+    rc = cli_main(_doctor_argv(tmp_path))
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    db_check = report["checks"]["state_db"]
+    assert "size_bytes" in db_check
+    assert db_check["size_bytes"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Human-readable default
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_default_output_is_human_readable_text(tmp_path, capsys, fake_store):
+    _init_db_at(tmp_path)
+    rc = cli_main(_doctor_argv(tmp_path, json_output=False))
+    assert rc == 0
+    out = capsys.readouterr().out
+
+    # It's not JSON — parsing as JSON must fail loudly.
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(out)
+
+    # Headings for every check present.
+    for heading in (
+        "## config", "## state_db", "## auth_garmin",
+        "## skills", "## domains", "## sources", "## today",
+    ):
+        assert heading in out
+
+    # Overall status is surfaced.
+    assert "overall:" in out

--- a/safety/tests/test_cli_init_doctor.py
+++ b/safety/tests/test_cli_init_doctor.py
@@ -246,7 +246,9 @@ def _doctor_argv(tmp_path: Path, **overrides) -> list[str]:
         "skills-dest": str(tmp_path / "skills"),
     }
     paths.update({k.replace("_", "-"): v for k, v in overrides.items()})
-    argv = ["doctor"]
+    # Default stdout shape is human-readable (M5); existing assertions
+    # parse JSON, so every test passes --json explicitly.
+    argv = ["doctor", "--json"]
     for flag, value in paths.items():
         argv += [f"--{flag}", value]
     return argv

--- a/src/health_agent_infra/cli.py
+++ b/src/health_agent_infra/cli.py
@@ -3058,163 +3058,58 @@ def _worst_status(statuses: list[str]) -> str:
 def cmd_doctor(args: argparse.Namespace) -> int:
     """Read-only diagnostics against the actual v1 runtime surfaces.
 
-    Reports what is present vs missing for each first-run piece — config,
-    state DB + schema version, Garmin credentials, skills install — plus
-    the package version. Does not mutate anything; every state-changing
-    step belongs to ``hai init`` or a targeted subcommand.
+    Seven checks: config, state DB + schema version + size, Garmin
+    credentials, skills install, domain registry, per-source sync
+    freshness (from sync_run_log, M2), and today's proposal /
+    recommendation / pending-review counts (M5).
 
-    Exit code 0 for ``ok`` or ``warn`` overall; 2 for ``fail`` (malformed
-    config on disk). ``warn`` is the normal pre-setup state so the check
-    stays agent-friendly — an agent or shell script can run ``hai doctor
-    && hai daily`` without getting blocked by a missing-auth warning.
+    Default output is human-readable text. Pass ``--json`` for the
+    structured dict an agent can parse.
+
+    Exit code: 0 for ``ok`` or ``warn`` overall; 2 for ``fail``
+    (malformed config on disk). ``warn`` is the normal pre-setup state
+    so ``hai doctor && hai daily`` isn't blocked by a missing-auth
+    warning.
     """
 
-    from health_agent_infra.core.state import (
-        current_schema_version,
-        open_connection,
-        resolve_db_path,
-    )
-    from health_agent_infra.core.state.store import discover_migrations
+    from health_agent_infra.core.doctor import build_report, render_text
+    from health_agent_infra.core.state import resolve_db_path
 
-    report: dict[str, Any] = {
-        "version": _PACKAGE_VERSION,
-        "checks": {},
-    }
-
-    # ---- config ----
     thresholds_path = (
         Path(args.thresholds_path).expanduser()
         if args.thresholds_path
         else user_config_path()
     )
-    if not thresholds_path.exists():
-        report["checks"]["config"] = {
-            "status": "warn",
-            "path": str(thresholds_path),
-            "reason": "thresholds file not present; defaults in effect",
-            "hint": "run `hai init` or `hai config init`",
-        }
-    else:
-        try:
-            load_thresholds(path=thresholds_path)
-            report["checks"]["config"] = {
-                "status": "ok",
-                "path": str(thresholds_path),
-            }
-        except ConfigError as exc:
-            report["checks"]["config"] = {
-                "status": "fail",
-                "path": str(thresholds_path),
-                "reason": str(exc),
-                "hint": "repair the TOML or regenerate with `hai config init --force`",
-            }
-
-    # ---- state DB + migration state ----
     db_path = resolve_db_path(args.db_path)
-    if not db_path.exists():
-        report["checks"]["state_db"] = {
-            "status": "warn",
-            "path": str(db_path),
-            "reason": "state DB file not present",
-            "hint": "run `hai init` or `hai state init`",
-        }
-    else:
-        conn = open_connection(db_path)
-        try:
-            current = current_schema_version(conn)
-        finally:
-            conn.close()
-        packaged = discover_migrations()
-        head = max((v for v, _, _ in packaged), default=0)
-        if current < head:
-            report["checks"]["state_db"] = {
-                "status": "warn",
-                "path": str(db_path),
-                "schema_version": current,
-                "head_version": head,
-                "pending_migrations": head - current,
-                "reason": f"{head - current} pending migration(s)",
-                "hint": "run `hai state migrate`",
-            }
-        else:
-            report["checks"]["state_db"] = {
-                "status": "ok",
-                "path": str(db_path),
-                "schema_version": current,
-                "head_version": head,
-            }
+    skills_dest = Path(args.skills_dest).expanduser()
 
-    # ---- Garmin auth ----
-    store = _credential_store_for(args)
-    auth_status = store.garmin_status()
-    if auth_status["credentials_available"]:
-        if auth_status["keyring"]["password_present"]:
-            source = "keyring"
-        else:
-            source = "env"
-        report["checks"]["auth_garmin"] = {
-            "status": "ok",
-            "credentials_source": source,
-        }
-    else:
-        report["checks"]["auth_garmin"] = {
-            "status": "warn",
-            "reason": "no Garmin credentials stored",
-            "hint": (
-                "run `hai auth garmin` (interactive) or set "
-                "HAI_GARMIN_EMAIL + HAI_GARMIN_PASSWORD in the environment"
-            ),
-        }
-
-    # ---- skills ----
-    dest = Path(args.skills_dest).expanduser()
     with _skills_source() as skills_source:
         packaged_names = (
             sorted(p.name for p in skills_source.iterdir() if p.is_dir())
             if skills_source.exists()
             else []
         )
-    if not dest.exists():
-        report["checks"]["skills"] = {
-            "status": "warn",
-            "dest": str(dest),
-            "packaged_count": len(packaged_names),
-            "installed_count": 0,
-            "reason": "skills destination does not exist",
-            "hint": "run `hai init` or `hai setup-skills`",
-        }
-    else:
-        installed = sorted(p.name for p in dest.iterdir() if p.is_dir())
-        missing = sorted(set(packaged_names) - set(installed))
-        if missing:
-            report["checks"]["skills"] = {
-                "status": "warn",
-                "dest": str(dest),
-                "installed_count": len(installed),
-                "packaged_count": len(packaged_names),
-                "missing": missing,
-                "hint": "run `hai setup-skills` to install missing skills",
-            }
-        else:
-            report["checks"]["skills"] = {
-                "status": "ok",
-                "dest": str(dest),
-                "installed_count": len(installed),
-                "packaged_count": len(packaged_names),
-            }
 
-    # ---- domains (static — the six v1 domains ship with the wheel) ----
-    report["checks"]["domains"] = {
-        "status": "ok",
-        "domains": sorted(_DAILY_SUPPORTED_DOMAINS),
-    }
+    as_of_date = _coerce_date(getattr(args, "as_of", None))
 
-    overall = _worst_status(
-        [c["status"] for c in report["checks"].values()]
+    report = build_report(
+        version=_PACKAGE_VERSION,
+        thresholds_path=thresholds_path,
+        db_path=db_path,
+        skills_dest=skills_dest,
+        packaged_skill_names=packaged_names,
+        domain_names=sorted(_DAILY_SUPPORTED_DOMAINS),
+        credential_store=_credential_store_for(args),
+        user_id=getattr(args, "user_id", "u_local_1"),
+        as_of_date=as_of_date,
     )
-    report["overall_status"] = overall
-    _emit_json(report)
-    return 2 if overall == "fail" else 0
+
+    if getattr(args, "json", False):
+        _emit_json(report.to_dict())
+    else:
+        sys.stdout.write(render_text(report))
+
+    return 2 if report.overall_status == "fail" else 0
 
 
 # ---------------------------------------------------------------------------
@@ -3875,6 +3770,15 @@ def build_parser() -> argparse.ArgumentParser:
     p_doctor.add_argument("--skills-dest", default=str(DEFAULT_CLAUDE_SKILLS_DIR),
                           help="Skills destination to inspect (default: "
                                "~/.claude/skills/).")
+    p_doctor.add_argument("--user-id", default="u_local_1",
+                          help="Which user's sync history + today counts to "
+                               "report. Default: u_local_1.")
+    p_doctor.add_argument("--as-of", default=None,
+                          help="Anchor date for freshness + today counts, "
+                               "ISO-8601. Default: today (UTC).")
+    p_doctor.add_argument("--json", action="store_true",
+                          help="Emit the structured report dict as JSON "
+                               "instead of the human-readable text view.")
     p_doctor.set_defaults(func=cmd_doctor)
 
     p_classify = sub.add_parser(

--- a/src/health_agent_infra/core/doctor/__init__.py
+++ b/src/health_agent_infra/core/doctor/__init__.py
@@ -1,0 +1,24 @@
+"""Aggregated read-only diagnostics for ``hai doctor``.
+
+One module because the checks are tiny and share the same
+``{name: {status, ...}}`` shape. The public surface is
+:func:`build_report` (which runs every check against a resolved
+environment) and :func:`render_text` (which formats the report for
+human consumption). The CLI layer wires these two together and picks
+its output format based on ``--json``.
+"""
+
+from health_agent_infra.core.doctor.checks import (
+    DoctorReport,
+    build_report,
+    worst_status,
+)
+from health_agent_infra.core.doctor.render import render_text
+
+
+__all__ = [
+    "DoctorReport",
+    "build_report",
+    "render_text",
+    "worst_status",
+]

--- a/src/health_agent_infra/core/doctor/checks.py
+++ b/src/health_agent_infra/core/doctor/checks.py
@@ -1,0 +1,371 @@
+"""Read-only diagnostic checks aggregated by ``hai doctor``.
+
+Every check returns a plain dict with a ``status`` in
+``{"ok", "warn", "fail"}``. The orchestrator (:func:`build_report`)
+runs each check in turn and returns a :class:`DoctorReport` mapping
+check names to their result dicts, plus an ``overall_status`` derived
+from the worst individual status via :func:`worst_status`.
+
+Pure read: nothing in this module opens a write transaction, touches
+the filesystem beyond reads, or mutates credential state. Failure
+inside one check is local — the outer report still carries results
+for every other check so the operator sees the whole picture in one
+pass.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional, TypedDict
+
+
+class CheckResult(TypedDict, total=False):
+    status: str
+
+
+@dataclass
+class DoctorReport:
+    version: str
+    overall_status: str
+    checks: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "overall_status": self.overall_status,
+            "checks": self.checks,
+        }
+
+
+_STATUS_ORDER: dict[str, int] = {"ok": 0, "warn": 1, "fail": 2}
+
+
+def worst_status(statuses: list[str]) -> str:
+    """Return the worst of a list of statuses. Empty list → ``'ok'``."""
+
+    if not statuses:
+        return "ok"
+    worst = max(_STATUS_ORDER[s] for s in statuses)
+    return {0: "ok", 1: "warn", 2: "fail"}[worst]
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+def check_config(thresholds_path: Path) -> dict[str, Any]:
+    """Config file present? Parseable? Malformed?"""
+
+    from health_agent_infra.core.config import ConfigError, load_thresholds
+
+    if not thresholds_path.exists():
+        return {
+            "status": "warn",
+            "path": str(thresholds_path),
+            "reason": "thresholds file not present; defaults in effect",
+            "hint": "run `hai init` or `hai config init`",
+        }
+    try:
+        load_thresholds(path=thresholds_path)
+    except ConfigError as exc:
+        return {
+            "status": "fail",
+            "path": str(thresholds_path),
+            "reason": str(exc),
+            "hint": "repair the TOML or regenerate with `hai config init --force`",
+        }
+    return {"status": "ok", "path": str(thresholds_path)}
+
+
+def check_state_db(db_path: Path) -> dict[str, Any]:
+    """DB present + at schema HEAD? Also carries file size for ops visibility."""
+
+    from health_agent_infra.core.state import (
+        current_schema_version,
+        open_connection,
+    )
+    from health_agent_infra.core.state.store import discover_migrations
+
+    if not db_path.exists():
+        return {
+            "status": "warn",
+            "path": str(db_path),
+            "reason": "state DB file not present",
+            "hint": "run `hai init` or `hai state init`",
+        }
+
+    conn = open_connection(db_path)
+    try:
+        current = current_schema_version(conn)
+    finally:
+        conn.close()
+
+    packaged = discover_migrations()
+    head = max((v for v, _, _ in packaged), default=0)
+    # DB size is the raw file size of the main DB file. SQLite's WAL and
+    # shm sidecars aren't included — they're transient and inflate the
+    # number for an operator trying to read "how much space is my data
+    # taking."
+    size_bytes = db_path.stat().st_size
+
+    base = {
+        "path": str(db_path),
+        "schema_version": current,
+        "head_version": head,
+        "size_bytes": size_bytes,
+    }
+    if current < head:
+        base.update({
+            "status": "warn",
+            "pending_migrations": head - current,
+            "reason": f"{head - current} pending migration(s)",
+            "hint": "run `hai state migrate`",
+        })
+    else:
+        base["status"] = "ok"
+    return base
+
+
+def check_auth_garmin(store: Any) -> dict[str, Any]:
+    """Credential presence only — never reads the secret value."""
+
+    status = store.garmin_status()
+    if not status["credentials_available"]:
+        return {
+            "status": "warn",
+            "reason": "no Garmin credentials stored",
+            "hint": (
+                "run `hai auth garmin` (interactive) or set "
+                "HAI_GARMIN_EMAIL + HAI_GARMIN_PASSWORD in the environment"
+            ),
+        }
+    source = "keyring" if status["keyring"]["password_present"] else "env"
+    return {"status": "ok", "credentials_source": source}
+
+
+def check_skills(skills_dest: Path, packaged_names: list[str]) -> dict[str, Any]:
+    """Skills destination populated with every packaged skill?"""
+
+    if not skills_dest.exists():
+        return {
+            "status": "warn",
+            "dest": str(skills_dest),
+            "packaged_count": len(packaged_names),
+            "installed_count": 0,
+            "reason": "skills destination does not exist",
+            "hint": "run `hai init` or `hai setup-skills`",
+        }
+    installed = sorted(p.name for p in skills_dest.iterdir() if p.is_dir())
+    missing = sorted(set(packaged_names) - set(installed))
+    base = {
+        "dest": str(skills_dest),
+        "installed_count": len(installed),
+        "packaged_count": len(packaged_names),
+    }
+    if missing:
+        base.update({
+            "status": "warn",
+            "missing": missing,
+            "hint": "run `hai setup-skills` to install missing skills",
+        })
+    else:
+        base["status"] = "ok"
+    return base
+
+
+def check_domains(domains: list[str]) -> dict[str, Any]:
+    """Static check — the six v1 domains ship with the wheel; always ok."""
+
+    return {"status": "ok", "domains": sorted(domains)}
+
+
+def check_sources(
+    db_path: Path,
+    *,
+    user_id: str,
+    as_of_date: date,
+) -> dict[str, Any]:
+    """Per-source last-successful-sync timestamps + staleness hours.
+
+    Built on the same sync_run_log reader the snapshot ``sources``
+    block uses (M2). Status is informational only — sources without a
+    sync row yet surface as ``unknown`` rather than ``warn`` because
+    "I haven't pulled Garmin on this machine yet" is a normal first-
+    run state, not a malfunction.
+    """
+
+    if not db_path.exists():
+        return {
+            "status": "warn",
+            "reason": "state DB not initialised — no sync history to read",
+            "hint": "run `hai state init`",
+            "sources": {},
+        }
+
+    try:
+        from health_agent_infra.core.state import open_connection
+        from health_agent_infra.core.state.sync_log import (
+            latest_successful_sync_per_source,
+        )
+    except ImportError:
+        return {
+            "status": "ok",
+            "sources": {},
+            "reason": "sync_run_log unavailable in this build",
+        }
+
+    conn = open_connection(db_path)
+    try:
+        rows = latest_successful_sync_per_source(conn, user_id=user_id)
+    except sqlite3.OperationalError:
+        # Pre-migration-008 DB.
+        rows = {}
+    finally:
+        conn.close()
+
+    anchor = datetime.combine(
+        as_of_date + timedelta(days=1), time.min, tzinfo=timezone.utc,
+    )
+    sources: dict[str, Any] = {}
+    for source, row in rows.items():
+        completed_at_raw = row.get("completed_at") or row.get("started_at")
+        try:
+            completed_at = datetime.fromisoformat(completed_at_raw)
+            if completed_at.tzinfo is None:
+                completed_at = completed_at.replace(tzinfo=timezone.utc)
+            staleness = round(
+                (anchor - completed_at).total_seconds() / 3600.0, 2,
+            )
+        except (TypeError, ValueError):
+            staleness = None
+        sources[source] = {
+            "last_successful_sync_at": completed_at_raw,
+            "staleness_hours": staleness,
+        }
+
+    if not sources:
+        return {
+            "status": "ok",
+            "sources": {},
+            "reason": "no sync history yet (run `hai pull` or `hai intake *`)",
+        }
+    return {"status": "ok", "sources": sources}
+
+
+def check_today(
+    db_path: Path,
+    *,
+    user_id: str,
+    as_of_date: date,
+) -> dict[str, Any]:
+    """Counts of proposals / recommendations / pending reviews for today.
+
+    Pending reviews = review_event rows whose review_at <= end-of-day
+    UTC on as_of_date and whose review_event_id has no matching
+    review_outcome yet. These are the actions an operator might want to
+    surface to the user today.
+    """
+
+    if not db_path.exists():
+        return {
+            "status": "warn",
+            "reason": "state DB not initialised",
+            "hint": "run `hai state init`",
+        }
+
+    from health_agent_infra.core.state import open_connection
+
+    conn = open_connection(db_path)
+    try:
+        try:
+            proposals = conn.execute(
+                "SELECT COUNT(*) AS n FROM proposal_log "
+                "WHERE for_date = ? AND user_id = ?",
+                (as_of_date.isoformat(), user_id),
+            ).fetchone()["n"]
+            recommendations = conn.execute(
+                "SELECT COUNT(*) AS n FROM recommendation_log "
+                "WHERE for_date = ? AND user_id = ?",
+                (as_of_date.isoformat(), user_id),
+            ).fetchone()["n"]
+            # A "pending review" is scheduled on or before as_of_date's
+            # end-of-day AND has no outcome row yet.
+            review_ceiling = datetime.combine(
+                as_of_date + timedelta(days=1), time.min, tzinfo=timezone.utc,
+            ).isoformat()
+            pending_reviews = conn.execute(
+                "SELECT COUNT(*) AS n FROM review_event re "
+                "WHERE re.user_id = ? "
+                "  AND re.review_at <= ? "
+                "  AND NOT EXISTS ("
+                "    SELECT 1 FROM review_outcome ro "
+                "    WHERE ro.review_event_id = re.review_event_id"
+                "  )",
+                (user_id, review_ceiling),
+            ).fetchone()["n"]
+        except sqlite3.OperationalError as exc:
+            return {
+                "status": "warn",
+                "reason": f"schema read failed: {exc}",
+                "hint": "run `hai state migrate`",
+            }
+    finally:
+        conn.close()
+
+    return {
+        "status": "ok",
+        "for_date": as_of_date.isoformat(),
+        "user_id": user_id,
+        "proposals": int(proposals),
+        "recommendations": int(recommendations),
+        "pending_reviews": int(pending_reviews),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def build_report(
+    *,
+    version: str,
+    thresholds_path: Path,
+    db_path: Path,
+    skills_dest: Path,
+    packaged_skill_names: list[str],
+    domain_names: list[str],
+    credential_store: Any,
+    user_id: str,
+    as_of_date: Optional[date] = None,
+) -> DoctorReport:
+    """Run every check and return a :class:`DoctorReport`.
+
+    Order matters only for presentation — status roll-up is symmetric.
+    The "today" counts use ``as_of_date`` (defaults to today UTC) so
+    an operator debugging yesterday's state can pass ``--as-of``
+    without rewiring the rest of the checks.
+    """
+
+    as_of = as_of_date if as_of_date is not None else datetime.now(timezone.utc).date()
+
+    checks: dict[str, dict[str, Any]] = {
+        "config": check_config(thresholds_path),
+        "state_db": check_state_db(db_path),
+        "auth_garmin": check_auth_garmin(credential_store),
+        "skills": check_skills(skills_dest, packaged_skill_names),
+        "domains": check_domains(domain_names),
+        "sources": check_sources(db_path, user_id=user_id, as_of_date=as_of),
+        "today": check_today(db_path, user_id=user_id, as_of_date=as_of),
+    }
+
+    overall = worst_status([c["status"] for c in checks.values()])
+    return DoctorReport(
+        version=version,
+        overall_status=overall,
+        checks=checks,
+    )

--- a/src/health_agent_infra/core/doctor/render.py
+++ b/src/health_agent_infra/core/doctor/render.py
@@ -1,0 +1,105 @@
+"""Human-readable renderer for :class:`DoctorReport`.
+
+Pure function of the report dict; no I/O. The CLI layer picks between
+this and ``json.dumps`` based on the ``--json`` flag.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from health_agent_infra.core.doctor.checks import DoctorReport
+
+
+_STATUS_GLYPH: dict[str, str] = {
+    "ok": "[OK]",
+    "warn": "[WARN]",
+    "fail": "[FAIL]",
+}
+
+
+def render_text(report: DoctorReport) -> str:
+    """Return a multi-line plain-text rendering suitable for terminals.
+
+    Format: one "## <check>" heading per check, with the status glyph
+    on the heading line and the rest of the fields indented. Ordering
+    matches the insertion order of ``report.checks`` so the output is
+    deterministic.
+    """
+
+    lines: list[str] = []
+    lines.append(f"hai doctor — v{report.version}")
+    lines.append(f"overall: {_STATUS_GLYPH.get(report.overall_status, '[?]')} "
+                 f"{report.overall_status}")
+    lines.append("")
+
+    for name, result in report.checks.items():
+        lines.extend(_render_check(name, result))
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_check(name: str, result: dict[str, Any]) -> list[str]:
+    status = result.get("status", "?")
+    glyph = _STATUS_GLYPH.get(status, "[?]")
+    header = f"## {name}  {glyph} {status}"
+    body: list[str] = [header]
+
+    # Per-check special-case rendering for the fields that benefit
+    # from structured display. Everything else falls through to the
+    # generic "key: value" line.
+    if name == "sources":
+        body.extend(_render_sources(result))
+        return body
+    if name == "today":
+        body.extend(_render_today(result))
+        return body
+
+    for key, value in result.items():
+        if key == "status":
+            continue
+        if key == "domains" and isinstance(value, list):
+            body.append(f"  {key}: {', '.join(value)}")
+            continue
+        if key == "missing" and isinstance(value, list):
+            body.append(f"  missing: {', '.join(value)}")
+            continue
+        body.append(f"  {key}: {value}")
+    return body
+
+
+def _render_sources(result: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    if "reason" in result:
+        lines.append(f"  reason: {result['reason']}")
+    if "hint" in result:
+        lines.append(f"  hint: {result['hint']}")
+    sources = result.get("sources") or {}
+    if not sources:
+        if "reason" not in result:
+            lines.append("  (no sync history yet)")
+        return lines
+    for source, info in sorted(sources.items()):
+        stale = info.get("staleness_hours")
+        stale_str = "unknown" if stale is None else f"{stale:.1f}h"
+        lines.append(
+            f"  {source}: last={info.get('last_successful_sync_at')} "
+            f"stale={stale_str}"
+        )
+    return lines
+
+
+def _render_today(result: dict[str, Any]) -> list[str]:
+    if "reason" in result:
+        lines = [f"  reason: {result['reason']}"]
+        if "hint" in result:
+            lines.append(f"  hint: {result['hint']}")
+        return lines
+    return [
+        f"  for_date: {result.get('for_date')}",
+        f"  user_id: {result.get('user_id')}",
+        f"  proposals: {result.get('proposals')}",
+        f"  recommendations: {result.get('recommendations')}",
+        f"  pending_reviews: {result.get('pending_reviews')}",
+    ]


### PR DESCRIPTION
## Summary
- Extract doctor checks into `core/doctor/` (`checks.py` + `render.py`); CLI is just orchestration.
- Two new checks: `sources` (per-source freshness from `sync_run_log`, shares M2's end-of-day anchor) and `today` (proposal/recommendation/pending-review counts for `(as_of_date, user_id)`). `state_db` gains `size_bytes`.
- Output format: default is human-readable text; pass `--json` for the structured dict. New `--user-id` / `--as-of` flags feed the new checks.

## Test plan
- [x] `uv run pytest safety/tests -q` — 1375 passing
- [x] New `test_cli_doctor.py` covers sources/today/size and the human-readable default; existing `test_cli_init_doctor.py` updated to pass `--json` explicitly
- [x] Smoke: `hai doctor` renders clean text on a fresh DB; `--json` emits the structured shape