### PR TITLE
M6: pull adapter resilience — retry + rate-limit + partial-day telemetry

### DIFF
--- a/safety/tests/test_cli_pull_live_and_auth.py
+++ b/safety/tests/test_cli_pull_live_and_auth.py
@@ -271,7 +271,12 @@ def test_build_live_adapter_returns_adapter_when_creds_and_client_ok(monkeypatch
     class StubClient:
         def fetch_day(self, day):
             return {}
-    monkeypatch.setattr(cli_mod, "build_default_client", lambda creds: StubClient())
+    # M6 wired retry_config through; accept kwargs so the stub keeps
+    # matching the real signature.
+    monkeypatch.setattr(
+        cli_mod, "build_default_client",
+        lambda creds, **kwargs: StubClient(),
+    )
 
     import argparse
     args = argparse.Namespace(live=True, history_days=3)

--- a/safety/tests/test_core_config.py
+++ b/safety/tests/test_core_config.py
@@ -35,8 +35,13 @@ from health_agent_infra.core.config import (
 # DEFAULT_THRESHOLDS shape
 # ---------------------------------------------------------------------------
 
-def test_default_thresholds_has_three_top_level_sections():
-    assert set(DEFAULT_THRESHOLDS.keys()) == {"classify", "policy", "synthesis"}
+def test_default_thresholds_has_expected_top_level_sections():
+    # M6 added "pull" (garmin_live retry knobs); prior PRs cemented
+    # classify / policy / synthesis. This set grows when a new config
+    # surface lands — the test should be updated alongside the section.
+    assert set(DEFAULT_THRESHOLDS.keys()) == {
+        "classify", "policy", "synthesis", "pull",
+    }
 
 
 def test_default_thresholds_recovery_bands_present():

--- a/safety/tests/test_garmin_live_retry.py
+++ b/safety/tests/test_garmin_live_retry.py
@@ -1,0 +1,329 @@
+"""M6 — Garmin live adapter retry + partial-day telemetry.
+
+Contracts pinned:
+
+  1. ``_safe_call_with_retry`` retries transient/rate-limit errors up
+     to ``max_attempts``, returns None + error context on exhaustion.
+  2. A 4xx-non-429 status code short-circuits to None after one try.
+  3. A 429 response is retried when ``retry_on_rate_limit`` is on;
+     skipped when it's off.
+  4. ``Retry-After`` header surfaces as ``context.retry_after`` and
+     the retry wait honours it (capped at ``max_delay_seconds``).
+  5. ``GarminLiveAdapter.load()`` sets ``last_pull_partial`` +
+     ``last_pull_failed_days`` when any per-day fetch exhausts retries.
+  6. ``retry_config_from_thresholds`` reads from the ``[pull.garmin_live]``
+     block; missing keys fall back to defaults.
+  7. Happy-path: a client that succeeds on its first call returns
+     cleanly with ``last_pull_partial == False``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+from health_agent_infra.core.config import DEFAULT_THRESHOLDS
+from health_agent_infra.core.pull.garmin_live import (
+    GarminLiveAdapter,
+    RetryConfig,
+    _classify_http_error,
+    _safe_call_with_retry,
+    retry_config_from_thresholds,
+)
+
+
+class _NoSleep:
+    """Replacement for the retry helper's sleep_fn — never actually waits.
+
+    Records each call so tests can assert retry count without spending
+    real wall time.
+    """
+
+    def __init__(self):
+        self.calls: list[tuple[int, dict]] = []
+
+    def __call__(self, attempt, config, context):
+        self.calls.append((attempt, dict(context)))
+
+
+# ---------------------------------------------------------------------------
+# HTTP classifier
+# ---------------------------------------------------------------------------
+
+
+def test_classifier_recognises_429_as_rate_limit():
+    class RateLimited(Exception):
+        status_code = 429
+
+    cat, code, _ctx = _classify_http_error(RateLimited("slow down"))
+    assert cat == "rate_limit"
+    assert code == 429
+
+
+def test_classifier_recognises_500_range_as_transient():
+    class ServerError(Exception):
+        status_code = 503
+
+    cat, code, _ = _classify_http_error(ServerError("bad gateway"))
+    assert cat == "transient"
+    assert code == 503
+
+
+def test_classifier_recognises_400_non_429_as_permanent():
+    class NotFound(Exception):
+        status_code = 404
+
+    cat, code, _ = _classify_http_error(NotFound("nope"))
+    assert cat == "permanent"
+    assert code == 404
+
+
+def test_classifier_defaults_unknown_exceptions_to_transient():
+    cat, code, _ = _classify_http_error(RuntimeError("network blip"))
+    assert cat == "transient"
+    assert code is None
+
+
+def test_classifier_extracts_retry_after_header():
+    class _Resp:
+        status_code = 429
+        headers = {"Retry-After": "7"}
+
+    class RateLimited(Exception):
+        response = _Resp()
+
+    cat, _, ctx = _classify_http_error(RateLimited("slow"))
+    assert cat == "rate_limit"
+    assert ctx["retry_after"] == 7.0
+
+
+# ---------------------------------------------------------------------------
+# _safe_call_with_retry
+# ---------------------------------------------------------------------------
+
+
+def test_retry_returns_first_success_without_retrying():
+    calls = 0
+
+    def fn():
+        nonlocal calls
+        calls += 1
+        return "ok"
+
+    sleeper = _NoSleep()
+    result, err = _safe_call_with_retry(
+        fn, config=RetryConfig(max_attempts=3), sleep_fn=sleeper,
+    )
+    assert result == "ok"
+    assert err is None
+    assert calls == 1
+    assert sleeper.calls == []
+
+
+def test_retry_recovers_after_transient_failures():
+    calls = 0
+
+    def fn():
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise RuntimeError("flake")
+        return "ok"
+
+    sleeper = _NoSleep()
+    result, err = _safe_call_with_retry(
+        fn, config=RetryConfig(max_attempts=3), sleep_fn=sleeper,
+    )
+    assert result == "ok"
+    assert err is None
+    assert calls == 3
+    # Two sleeps between the three attempts.
+    assert len(sleeper.calls) == 2
+
+
+def test_retry_exhausts_and_returns_none_with_last_context():
+    def fn():
+        class Err(Exception):
+            status_code = 503
+        raise Err("server blew up")
+
+    sleeper = _NoSleep()
+    result, err = _safe_call_with_retry(
+        fn, config=RetryConfig(max_attempts=3), sleep_fn=sleeper,
+    )
+    assert result is None
+    assert err is not None
+    assert err["category"] == "transient"
+    assert len(sleeper.calls) == 2
+
+
+def test_retry_short_circuits_on_permanent_4xx():
+    calls = 0
+
+    def fn():
+        nonlocal calls
+        calls += 1
+
+        class Err(Exception):
+            status_code = 403
+        raise Err("forbidden")
+
+    sleeper = _NoSleep()
+    result, err = _safe_call_with_retry(
+        fn, config=RetryConfig(max_attempts=5), sleep_fn=sleeper,
+    )
+    assert result is None
+    assert err["category"] == "permanent"
+    assert calls == 1
+    assert sleeper.calls == []
+
+
+def test_retry_respects_retry_on_rate_limit_false():
+    calls = 0
+
+    def fn():
+        nonlocal calls
+        calls += 1
+
+        class Err(Exception):
+            status_code = 429
+        raise Err("rate")
+
+    sleeper = _NoSleep()
+    result, err = _safe_call_with_retry(
+        fn,
+        config=RetryConfig(max_attempts=5, retry_on_rate_limit=False),
+        sleep_fn=sleeper,
+    )
+    assert result is None
+    assert err["category"] == "rate_limit"
+    assert calls == 1
+    assert sleeper.calls == []
+
+
+def test_retry_surfaces_retry_after_to_sleep_fn():
+    calls = 0
+
+    def fn():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            class _Resp:
+                status_code = 429
+                headers = {"Retry-After": "2"}
+
+            class Err(Exception):
+                response = _Resp()
+            raise Err("rate")
+        return "ok"
+
+    sleeper = _NoSleep()
+    _safe_call_with_retry(
+        fn, config=RetryConfig(max_attempts=3), sleep_fn=sleeper,
+    )
+    assert sleeper.calls[0][1]["retry_after"] == 2.0
+
+
+# ---------------------------------------------------------------------------
+# retry_config_from_thresholds
+# ---------------------------------------------------------------------------
+
+
+def test_retry_config_reads_from_thresholds():
+    cfg = retry_config_from_thresholds({
+        "pull": {"garmin_live": {
+            "max_attempts": 5,
+            "base_delay_seconds": 0.5,
+            "max_delay_seconds": 8.0,
+            "retry_on_rate_limit": False,
+        }},
+    })
+    assert cfg.max_attempts == 5
+    assert cfg.base_delay_seconds == 0.5
+    assert cfg.max_delay_seconds == 8.0
+    assert cfg.retry_on_rate_limit is False
+
+
+def test_retry_config_falls_back_to_defaults_on_missing_keys():
+    cfg = retry_config_from_thresholds(None)
+    assert cfg.max_attempts == 3
+    assert cfg.base_delay_seconds == 1.0
+    assert cfg.max_delay_seconds == 4.0
+    assert cfg.retry_on_rate_limit is True
+
+
+def test_default_thresholds_has_garmin_live_section():
+    """Pin the shape the config loader and adapter agree on."""
+
+    garmin = DEFAULT_THRESHOLDS["pull"]["garmin_live"]
+    assert set(garmin.keys()) == {
+        "max_attempts",
+        "base_delay_seconds",
+        "max_delay_seconds",
+        "retry_on_rate_limit",
+    }
+
+
+# ---------------------------------------------------------------------------
+# GarminLiveAdapter partial-pull telemetry
+# ---------------------------------------------------------------------------
+
+
+class _FlakyDaysClient:
+    """Fake client that fails specific days and succeeds on others.
+
+    ``fails_until``: per-day attempt count at which success returns.
+    Any day not listed is treated as ``1`` (succeeds on first attempt).
+    """
+
+    def __init__(self, fails_until: dict[date, int]):
+        self._fails_until = fails_until
+        self._attempts: dict[date, int] = {}
+
+    def fetch_day(self, day: date) -> dict:
+        n = self._attempts.get(day, 0) + 1
+        self._attempts[day] = n
+        threshold = self._fails_until.get(day, 1)
+        if n < threshold:
+            raise RuntimeError(f"flake day={day} attempt={n}")
+        return {"date": day.isoformat()}
+
+
+def test_adapter_load_clean_run_sets_last_pull_partial_false():
+    as_of = date(2026, 4, 17)
+    client = _FlakyDaysClient({})
+    adapter = GarminLiveAdapter(
+        client=client, history_days=0,
+        retry_config=RetryConfig(max_attempts=3, base_delay_seconds=0, max_delay_seconds=0),
+    )
+    adapter.load(as_of)
+    assert adapter.last_pull_partial is False
+    assert adapter.last_pull_failed_days == []
+
+
+def test_adapter_load_marks_partial_when_a_day_exhausts_retries():
+    as_of = date(2026, 4, 17)
+    # Day fails 10 times → exhausts max_attempts=2.
+    client = _FlakyDaysClient({as_of: 10})
+    adapter = GarminLiveAdapter(
+        client=client, history_days=0,
+        retry_config=RetryConfig(max_attempts=2, base_delay_seconds=0, max_delay_seconds=0),
+    )
+    adapter.load(as_of)
+    assert adapter.last_pull_partial is True
+    assert adapter.last_pull_failed_days == [as_of.isoformat()]
+
+
+def test_adapter_load_recovers_after_one_retry():
+    as_of = date(2026, 4, 17)
+    # Fails once, succeeds on retry.
+    client = _FlakyDaysClient({as_of: 2})
+    adapter = GarminLiveAdapter(
+        client=client, history_days=0,
+        retry_config=RetryConfig(max_attempts=3, base_delay_seconds=0, max_delay_seconds=0),
+    )
+    pull = adapter.load(as_of)
+    assert adapter.last_pull_partial is False
+    assert pull["raw_daily_row"]["date"] == as_of.isoformat()

--- a/src/health_agent_infra/cli.py
+++ b/src/health_agent_infra/cli.py
@@ -167,12 +167,19 @@ def cmd_pull(args: argparse.Namespace) -> int:
     # maps "one logical day's evidence = one row" without pretending the
     # per-metric arrays are independent rows.
     rows = 1 if pull.get("raw_daily_row") is not None else 0
+    # M6: the live adapter exposes partial-pull telemetry on its
+    # instance so the pull dict's key set stays byte-identical to the
+    # CSV adapter. The CSV adapter has no partial concept, so attribute
+    # absence means "ok" by default.
+    partial = getattr(adapter, "last_pull_partial", False)
+    sync_status = "partial" if partial else "ok"
     _close_sync_row_ok(
         args.db_path,
         sync_id,
         rows_pulled=rows,
         rows_accepted=rows,
         duplicates_skipped=0,
+        status=sync_status,
     )
 
     payload = {
@@ -349,7 +356,15 @@ def _build_live_adapter(args: argparse.Namespace):
 
     Pulled into a helper so tests can monkeypatch the client-building step
     while exercising the real CLI arg parsing and credential flow.
+
+    M6: the adapter + client share a :class:`RetryConfig` derived from
+    the merged thresholds. A user TOML ``[pull.garmin_live]`` section
+    tunes attempts / backoff / rate-limit behavior without code edits.
     """
+
+    from health_agent_infra.core.pull.garmin_live import (
+        retry_config_from_thresholds,
+    )
 
     store = CredentialStore.default()
     credentials = store.load_garmin()
@@ -358,9 +373,20 @@ def _build_live_adapter(args: argparse.Namespace):
             "no Garmin credentials found. Run `hai auth garmin` or set "
             "HAI_GARMIN_EMAIL + HAI_GARMIN_PASSWORD."
         )
-    client = build_default_client(credentials)
+    try:
+        thresholds = load_thresholds()
+    except ConfigError:
+        # Malformed TOML is a config-level concern hai doctor surfaces;
+        # for a pull, fall back to packaged defaults rather than failing.
+        thresholds = None
+    retry_cfg = retry_config_from_thresholds(thresholds)
+    client = build_default_client(credentials, retry_config=retry_cfg)
     history_days = getattr(args, "history_days", 14)
-    return GarminLiveAdapter(client=client, history_days=history_days)
+    return GarminLiveAdapter(
+        client=client,
+        history_days=history_days,
+        retry_config=retry_cfg,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/health_agent_infra/core/config.py
+++ b/src/health_agent_infra/core/config.py
@@ -405,6 +405,25 @@ DEFAULT_THRESHOLDS: dict[str, Any] = {
             },
         },
     },
+    # M6 — pull-adapter resilience knobs. Applied inside the Garmin live
+    # adapter's per-field retry wrapper; CSV pulls ignore these. A user
+    # TOML can tune them under ``[pull.garmin_live]`` without editing
+    # code — a tight allowance for flaky networks or an aggressive
+    # backoff for rate-limited dev tokens.
+    "pull": {
+        "garmin_live": {
+            # Total attempts per upstream field call (1 initial + N-1 retries).
+            "max_attempts": 3,
+            # Exponential base delay between attempts. The nth retry
+            # waits ``min(base * 2**(n-1), max_delay)`` plus ±25% jitter.
+            "base_delay_seconds": 1.0,
+            "max_delay_seconds": 4.0,
+            # Whether 429 (rate limit) responses trigger a retry. Set to
+            # ``false`` to surface 429s immediately instead of waiting
+            # out the backoff.
+            "retry_on_rate_limit": True,
+        },
+    },
 }
 
 

--- a/src/health_agent_infra/core/pull/garmin_live.py
+++ b/src/health_agent_infra/core/pull/garmin_live.py
@@ -35,9 +35,11 @@ Design constraints from the plan:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import random
+import time
+from dataclasses import dataclass, field
 from datetime import date, timedelta
-from typing import Iterable, Optional, Protocol
+from typing import Any, Iterable, Optional, Protocol
 
 from health_agent_infra.core.pull.auth import GarminCredentials
 
@@ -116,7 +118,162 @@ class GarminLiveError(RuntimeError):
     Covers the bounded-blocker surface: missing ``garminconnect`` install,
     login failure, or an upstream client that raises on every call.
     CSV pull remains available either way.
+
+    ``context`` carries rate-limit / HTTP headers when the underlying
+    error surface exposed them — e.g. ``{"retry_after": 30}`` on a 429.
+    Callers that want to report "upstream asked us to wait 30s" can
+    read this without parsing the exception message string.
     """
+
+    def __init__(self, message: str, *, context: Optional[dict[str, Any]] = None) -> None:
+        super().__init__(message)
+        self.context: dict[str, Any] = dict(context) if context else {}
+
+
+# ---------------------------------------------------------------------------
+# Retry + classification helpers (M6)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    """Knobs for the per-field retry wrapper.
+
+    Defaults mirror the ``[pull.garmin_live]`` block in
+    :data:`core.config.DEFAULT_THRESHOLDS`. The CLI passes a merged
+    config through :func:`retry_config_from_thresholds` so a user TOML
+    can tune these without code edits.
+    """
+
+    max_attempts: int = 3
+    base_delay_seconds: float = 1.0
+    max_delay_seconds: float = 4.0
+    retry_on_rate_limit: bool = True
+
+
+def retry_config_from_thresholds(thresholds: Optional[dict[str, Any]]) -> RetryConfig:
+    """Derive a :class:`RetryConfig` from a merged thresholds dict."""
+
+    cfg = ((thresholds or {}).get("pull") or {}).get("garmin_live") or {}
+    return RetryConfig(
+        max_attempts=int(cfg.get("max_attempts", 3)),
+        base_delay_seconds=float(cfg.get("base_delay_seconds", 1.0)),
+        max_delay_seconds=float(cfg.get("max_delay_seconds", 4.0)),
+        retry_on_rate_limit=bool(cfg.get("retry_on_rate_limit", True)),
+    )
+
+
+def _classify_http_error(exc: BaseException) -> tuple[str, Optional[int], dict[str, Any]]:
+    """Return ``(category, status_code, context)`` for a raised exception.
+
+    Category is one of:
+      - ``"rate_limit"``: HTTP 429. Retry respects ``retry_on_rate_limit``.
+      - ``"transient"``: HTTP 5xx, network-like failures, or unclassifiable
+        exceptions (permissive default — a flake shouldn't fail a pull).
+      - ``"permanent"``: HTTP 4xx-non-429. Retrying won't help; stop.
+
+    The classification looks for ``.status_code`` first (common on
+    direct HTTP exception types), then ``.response.status_code``
+    (wrapper-style). Absent either, the exception is treated as
+    transient.
+
+    Context may include a ``retry_after`` key (seconds) when the
+    upstream response carried a ``Retry-After`` header — passed
+    through verbatim so the caller can surface it in logs /
+    ``GarminLiveError.context``.
+    """
+
+    status_code = getattr(exc, "status_code", None)
+    response = getattr(exc, "response", None)
+    if status_code is None and response is not None:
+        status_code = getattr(response, "status_code", None)
+
+    context: dict[str, Any] = {}
+    headers = None
+    if response is not None:
+        headers = getattr(response, "headers", None) or {}
+    if headers:
+        retry_after = headers.get("Retry-After") or headers.get("retry-after")
+        if retry_after is not None:
+            try:
+                context["retry_after"] = float(retry_after)
+            except (TypeError, ValueError):
+                context["retry_after"] = retry_after
+
+    if status_code is None:
+        return "transient", None, context
+    try:
+        code = int(status_code)
+    except (TypeError, ValueError):
+        return "transient", None, context
+
+    if code == 429:
+        return "rate_limit", code, context
+    if 500 <= code < 600:
+        return "transient", code, context
+    if 400 <= code < 500:
+        return "permanent", code, context
+    return "transient", code, context
+
+
+def _retry_sleep(
+    attempt: int, config: RetryConfig, context: dict[str, Any],
+) -> None:
+    """Sleep for the nth retry.
+
+    If ``context`` carries a numeric ``retry_after`` the caller honours
+    it (capped at ``max_delay_seconds`` to keep pulls from wedging for
+    minutes on a single 429). Otherwise: exponential backoff from
+    ``base_delay_seconds``, capped at ``max_delay_seconds``, ±25%
+    jitter.
+    """
+
+    retry_after = context.get("retry_after")
+    if isinstance(retry_after, (int, float)):
+        delay = min(float(retry_after), config.max_delay_seconds)
+    else:
+        delay = min(
+            config.base_delay_seconds * (2 ** (attempt - 1)),
+            config.max_delay_seconds,
+        )
+    # ±25% jitter so retries don't synchronise with other clients
+    # hitting the same rate-limited endpoint.
+    jitter = delay * 0.25 * (random.random() * 2 - 1)
+    total = max(0.0, delay + jitter)
+    if total > 0:
+        time.sleep(total)
+
+
+def _safe_call_with_retry(
+    fn, *args, config: RetryConfig, sleep_fn=_retry_sleep, **kwargs,
+) -> tuple[Any, Optional[dict[str, Any]]]:
+    """Invoke ``fn``, retry on transient/rate-limit errors per ``config``.
+
+    Returns ``(result, error_context)`` where ``result`` is either the
+    successful return value or ``None`` when every attempt failed, and
+    ``error_context`` is ``None`` on success or the last exception's
+    classified context dict on failure. A field that failed every
+    attempt becomes a partial-day signal: the caller propagates it
+    upward so the sync row can land ``status='partial'``.
+    """
+
+    last_ctx: dict[str, Any] = {}
+    last_category = "transient"
+    for attempt in range(1, max(1, config.max_attempts) + 1):
+        try:
+            return fn(*args, **kwargs), None
+        except Exception as exc:  # noqa: BLE001 — classifier handles shapes
+            category, _code, ctx = _classify_http_error(exc)
+            last_ctx = ctx
+            last_category = category
+            if category == "permanent":
+                break
+            if category == "rate_limit" and not config.retry_on_rate_limit:
+                break
+            if attempt < config.max_attempts:
+                sleep_fn(attempt, config, ctx)
+                continue
+    return None, {"category": last_category, **last_ctx}
 
 
 class GarminLiveClient(Protocol):
@@ -139,15 +296,58 @@ class GarminLiveAdapter:
     distinguishes live from CSV, while downstream projectors continue to
     key state rows on ``source='garmin'`` (that's hardcoded in the
     projector and independent of adapter provenance).
+
+    ``retry_config`` (M6) threads through per-field retry behavior —
+    the default mirrors :data:`core.config.DEFAULT_THRESHOLDS`'
+    ``[pull.garmin_live]``. The CLI passes a merged thresholds dict
+    down via :func:`retry_config_from_thresholds`.
     """
 
     client: GarminLiveClient
     history_days: int = 14
     source_name: str = "garmin_live"
+    retry_config: RetryConfig = field(default_factory=RetryConfig)
+    # M6 — partial-day telemetry updated each call to :meth:`load`.
+    # Kept off the returned pull dict so the CSV-contract key set stays
+    # byte-identical to the passive adapter; callers read these
+    # directly from the adapter instance when they need the telemetry.
+    last_pull_partial: bool = field(default=False, init=False, repr=False)
+    last_pull_failed_days: list[str] = field(
+        default_factory=list, init=False, repr=False,
+    )
 
     def load(self, as_of: date) -> dict:
+        """Return the normalised pull dict for ``as_of``.
+
+        When one or more upstream field-calls exhaust their retry
+        budget, the adapter still returns whatever succeeded (same
+        partial-field shape as the CSV adapter emits when CSV cells are
+        blank). The per-run telemetry (whether any day was partial,
+        which days failed) lands on :attr:`last_pull_partial` and
+        :attr:`last_pull_failed_days`; the CLI reads these to stamp
+        ``sync_run_log.status='partial'``.
+        """
+
         days = _window_days(as_of, self.history_days)
-        rows = [_normalise_row(day, self.client.fetch_day(day)) for day in days]
+        rows: list[dict] = []
+        partial = False
+        failed_days: list[str] = []
+        for day in days:
+            raw, err = _safe_call_with_retry(
+                self.client.fetch_day, day, config=self.retry_config,
+            )
+            if err is not None:
+                # A day that exhausted retries drops out of the raw
+                # series entirely — whether it's the target day (breaks
+                # raw_daily_row) or a historical day (shortens the
+                # per-metric series). Either way we mark partial so the
+                # operator knows the coverage is incomplete.
+                partial = True
+                failed_days.append(day.isoformat())
+            rows.append(_normalise_row(day, raw))
+
+        self.last_pull_partial = partial
+        self.last_pull_failed_days = failed_days
 
         return {
             "sleep": _extract_sleep(rows, as_of),
@@ -249,7 +449,11 @@ def _extract_raw_daily_row(rows: Iterable[dict], as_of: date) -> Optional[dict]:
 # ---------------------------------------------------------------------------
 
 
-def build_default_client(credentials: GarminCredentials) -> GarminLiveClient:
+def build_default_client(
+    credentials: GarminCredentials,
+    *,
+    retry_config: Optional[RetryConfig] = None,
+) -> GarminLiveClient:
     """Construct a live ``garminconnect``-backed client.
 
     Imports the upstream library lazily so tests (which mock at the
@@ -258,7 +462,9 @@ def build_default_client(credentials: GarminCredentials) -> GarminLiveClient:
 
     Any import or login failure is wrapped in ``GarminLiveError`` so
     callers can report a bounded blocker without catching a zoo of
-    upstream exception types.
+    upstream exception types. Login is also retry-guarded per
+    ``retry_config`` — rate-limited logins are the most annoying
+    failure mode in dev.
     """
 
     try:
@@ -269,12 +475,28 @@ def build_default_client(credentials: GarminCredentials) -> GarminLiveClient:
             "(`pip install garminconnect`) or fall back to CSV pull."
         ) from exc
 
-    try:
+    cfg = retry_config if retry_config is not None else RetryConfig()
+
+    last_exc: dict[str, Any] = {"message": None}
+
+    def _do_login():
         client = Garmin(credentials.email, credentials.password)
-        client.login()
-    except Exception as exc:  # upstream exceptions vary by version
-        raise GarminLiveError(f"Garmin login failed: {exc}") from exc
-    return _GarminConnectClient(client)
+        try:
+            client.login()
+        except Exception as exc:
+            last_exc["message"] = str(exc)
+            raise
+        return client
+
+    client, err = _safe_call_with_retry(_do_login, config=cfg)
+    if client is None:
+        detail = last_exc.get("message")
+        suffix = f": {detail}" if detail else ""
+        raise GarminLiveError(
+            f"Garmin login failed after {cfg.max_attempts} attempt(s){suffix}",
+            context=err or {},
+        )
+    return _GarminConnectClient(client, retry_config=cfg)
 
 
 class _GarminConnectClient:
@@ -284,16 +506,32 @@ class _GarminConnectClient:
     missing fields rather than failing the whole pull. Field mapping is
     deliberately conservative: only the fields downstream code reads are
     populated; everything else stays None and can be added as needed.
+
+    M6: per-endpoint calls retry on transient / rate-limit errors per
+    ``retry_config``. A 4xx-non-429 still short-circuits to None
+    (classifier marks it ``permanent``).
     """
 
-    def __init__(self, client) -> None:  # client: garminconnect.Garmin
+    def __init__(
+        self,
+        client,
+        *,
+        retry_config: Optional[RetryConfig] = None,
+    ) -> None:  # client: garminconnect.Garmin
         self._client = client
+        self._retry_config = retry_config if retry_config is not None else RetryConfig()
+
+    def _call(self, fn, *args, **kwargs):
+        result, _err = _safe_call_with_retry(
+            fn, *args, config=self._retry_config, **kwargs,
+        )
+        return result
 
     def fetch_day(self, day: date) -> dict:
         iso = day.isoformat()
         row: dict = {"date": iso}
 
-        stats = _safe_call(self._client.get_stats, iso) or {}
+        stats = self._call(self._client.get_stats, iso) or {}
         row["steps"] = stats.get("totalSteps")
         row["distance_m"] = stats.get("totalDistanceMeters")
         row["active_kcal"] = stats.get("activeKilocalories")
@@ -307,7 +545,7 @@ class _GarminConnectClient:
         row["all_day_stress"] = stats.get("averageStressLevel")
         row["body_battery"] = stats.get("bodyBatteryMostRecentValue")
 
-        sleep = _safe_call(self._client.get_sleep_data, iso) or {}
+        sleep = self._call(self._client.get_sleep_data, iso) or {}
         dto = sleep.get("dailySleepDTO") or {}
         row["sleep_deep_sec"] = dto.get("deepSleepSeconds")
         row["sleep_light_sec"] = dto.get("lightSleepSeconds")
@@ -322,7 +560,7 @@ class _GarminConnectClient:
         row["avg_sleep_respiration"] = dto.get("averageRespirationValue")
         row["avg_sleep_stress"] = dto.get("avgSleepStress")
 
-        hrv = _safe_call(self._client.get_hrv_data, iso) or {}
+        hrv = self._call(self._client.get_hrv_data, iso) or {}
         hrv_summary = hrv.get("hrvSummary") or {}
         row["health_hrv_value"] = hrv_summary.get("lastNightAvg")
         row["health_hrv_baseline_low"] = (
@@ -332,7 +570,7 @@ class _GarminConnectClient:
             (hrv_summary.get("baseline") or {}).get("balancedHigh")
         )
 
-        tr = _safe_call(self._client.get_training_readiness, iso)
+        tr = self._call(self._client.get_training_readiness, iso)
         if isinstance(tr, list):
             tr = tr[0] if tr else {}
         tr = tr or {}
@@ -345,7 +583,7 @@ class _GarminConnectClient:
         row["training_readiness_hrv_weekly_avg"] = tr.get("hrvScore")
         row["training_readiness_valid_sleep"] = tr.get("validSleep")
 
-        status = _safe_call(self._client.get_training_status, iso) or {}
+        status = self._call(self._client.get_training_status, iso) or {}
         most_recent = (status.get("mostRecentTrainingLoadBalance") or {})
         metrics = (most_recent.get("metricsTrainingLoadBalanceDTOMap") or {})
         # metrics is a dict keyed by device id; pick the first entry
@@ -368,18 +606,3 @@ class _GarminConnectClient:
                 row["training_status"] = None
 
         return row
-
-
-def _safe_call(fn, *args, **kwargs):
-    """Call ``fn`` and swallow any exception into ``None``.
-
-    Every upstream field we pull is optional — a single endpoint flaking
-    should not fail the whole pull. The adapter's raw_daily_row degrades
-    to None for missing fields, which is the same shape the CSV adapter
-    emits when the CSV has blank cells.
-    """
-
-    try:
-        return fn(*args, **kwargs)
-    except Exception:
-        return None


### PR DESCRIPTION
## Summary
- `RetryConfig` + `_safe_call_with_retry` in `core/pull/garmin_live.py`: classifies 429 / 5xx / 4xx-non-429 / unclassifiable exceptions, retries transient/rate-limit up to `max_attempts` with exponential backoff + ±25% jitter; Retry-After headers surface as `context.retry_after` and drive the wait.
- `GarminLiveError` gains a `context` dict; `build_default_client` login is retry-guarded with last-error detail preserved in the surfaced message.
- `GarminLiveAdapter.load()` sets `last_pull_partial` + `last_pull_failed_days` on the adapter instance when any per-day fetch exhausts retries. The pull dict's key set stays byte-identical to the CSV adapter.
- `cmd_pull` reads the telemetry and writes `sync_run_log.status='partial'` instead of `'ok'` when the pull was incomplete. `_build_live_adapter` threads a thresholds-derived `RetryConfig` into both client and adapter.
- New `[pull.garmin_live]` section in `DEFAULT_THRESHOLDS` exposes the knobs.

## Test plan
- [x] `uv run pytest safety/tests -q` — 1392 passing
- [x] New `test_garmin_live_retry.py` (17 cases) covers classifier, retry helper, config loader, adapter partial-pull telemetry
- [x] Pre-M6 tests updated for the config-section-count bump and the new `build_default_client` kwargs