### PR TITLE
M7: property-based + concurrency + migration-rollback tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ Issues = "https://github.com/dtcolligan/health_agent_infra/issues"
 dev = [
   "pytest>=9.0.3",
   "build>=1.2",
+  "hypothesis>=6.100",
 ]
 
 [project.scripts]

--- a/safety/tests/property/test_synthesis_idempotency.py
+++ b/safety/tests/property/test_synthesis_idempotency.py
@@ -1,0 +1,206 @@
+"""M7 — synthesis idempotency property test.
+
+Running ``run_synthesis`` twice on identical inputs must produce
+byte-equal persisted rows (modulo timestamp / autoincrement columns
+the runtime stamps per call). If this breaks, the canonical-plan
+replacement path is leaking state somewhere.
+
+Uses a small random sweep over proposal sets + snapshots — the
+invariant should hold regardless of how many domains or which X-rule
+configuration fires.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sqlite3
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+try:
+    from hypothesis import given, settings, strategies as st
+except ImportError:
+    pytest.skip("hypothesis not installed", allow_module_level=True)
+
+from health_agent_infra.core.schemas import canonical_daily_plan_id
+from health_agent_infra.core.state import (
+    initialize_database,
+    open_connection,
+    project_proposal,
+)
+from health_agent_infra.core.synthesis import run_synthesis
+from health_agent_infra.core.writeback.proposal import PROPOSAL_SCHEMA_VERSIONS
+
+
+FOR_DATE = date(2026, 4, 17)
+USER = "u_prop"
+
+
+# Columns the runtime stamps per call — they legitimately differ
+# between re-runs and must be excluded from the equality check.
+_VOLATILE_COLUMNS: frozenset[str] = frozenset({
+    "synthesized_at",
+    "fired_at",
+    "issued_at",
+    "produced_at",
+    "validated_at",
+    "projected_at",
+    "firing_id",
+    "outcome_id",
+    "sync_id",
+    "started_at",
+    "completed_at",
+})
+
+
+def _strip_volatile(row: sqlite3.Row) -> dict[str, Any]:
+    d = dict(row)
+    for k in list(d.keys()):
+        if k in _VOLATILE_COLUMNS:
+            d.pop(k)
+    # payload_json carries timestamps embedded in its JSON blob;
+    # normalise by re-dumping with volatile fields stripped.
+    if "payload_json" in d and d["payload_json"]:
+        try:
+            payload = json.loads(d["payload_json"])
+        except (TypeError, ValueError):
+            return d
+        if isinstance(payload, dict):
+            for k in list(payload.keys()):
+                if k in _VOLATILE_COLUMNS:
+                    payload.pop(k)
+            # Also strip nested follow_up.review_at which is derived
+            # from issued_at + a fixed delta.
+            fu = payload.get("follow_up")
+            if isinstance(fu, dict):
+                fu.pop("review_at", None)
+            d["payload_json"] = json.dumps(payload, sort_keys=True)
+    # synthesis_meta_json includes the run's wall-clock synthesized_at;
+    # strip that before compare.
+    if "synthesis_meta_json" in d and d["synthesis_meta_json"]:
+        try:
+            meta = json.loads(d["synthesis_meta_json"])
+        except (TypeError, ValueError):
+            return d
+        if isinstance(meta, dict):
+            meta.pop("synthesized_at", None)
+            d["synthesis_meta_json"] = json.dumps(meta, sort_keys=True)
+    return d
+
+
+def _snapshot_db(conn: sqlite3.Connection) -> dict[str, list[dict]]:
+    """Read every row from every synthesis table into plain dicts.
+
+    Synthesis writes to three tables: daily_plan, recommendation_log,
+    x_rule_firing (and updates proposal_log.daily_plan_id). We capture
+    all four so a leak anywhere surfaces.
+    """
+
+    snap: dict[str, list[dict]] = {}
+    for table in ("daily_plan", "recommendation_log", "x_rule_firing"):
+        rows = conn.execute(
+            f"SELECT * FROM {table} ORDER BY 1"  # noqa: S608 — fixed list
+        ).fetchall()
+        snap[table] = [_strip_volatile(r) for r in rows]
+    proposal_rows = conn.execute(
+        "SELECT proposal_id, daily_plan_id FROM proposal_log "
+        "ORDER BY proposal_id"
+    ).fetchall()
+    snap["proposal_log"] = [dict(r) for r in proposal_rows]
+    return snap
+
+
+def _make_proposal(domain: str, index: int) -> dict[str, Any]:
+    action_by_domain = {
+        "recovery": "proceed_with_planned_session",
+        "running": "proceed_with_planned_run",
+        "strength": "proceed_with_planned_session",
+        "sleep": "maintain_schedule",
+        "stress": "maintain_routine",
+        "nutrition": "maintain_targets",
+    }
+    return {
+        "schema_version": PROPOSAL_SCHEMA_VERSIONS[domain],
+        "proposal_id": f"prop_{FOR_DATE}_{USER}_{domain}_{index:02d}",
+        "user_id": USER,
+        "for_date": FOR_DATE.isoformat(),
+        "domain": domain,
+        "action": action_by_domain[domain],
+        "action_detail": None,
+        "rationale": [f"{domain}_baseline"],
+        "confidence": "high",
+        "uncertainty": [],
+        "policy_decisions": [{"rule_id": "r1", "decision": "allow", "note": "n"}],
+        "bounded": True,
+    }
+
+
+def _stressful_snapshot() -> dict[str, Any]:
+    return {
+        "recovery": {
+            "classified_state": {"sleep_debt_band": "moderate"},
+            "today": {"acwr_ratio": 1.0},
+        },
+        "sleep": {"classified_state": {"sleep_debt_band": "moderate"}},
+        "stress": {
+            "classified_state": {"garmin_stress_band": "high"},
+            "today": {"garmin_all_day_stress": 65, "body_battery_end_of_day": 45},
+            "today_garmin": 65, "today_body_battery": 45,
+        },
+        "running": {},
+    }
+
+
+@settings(derandomize=True, max_examples=5, deadline=None)
+@given(
+    domains=st.lists(
+        st.sampled_from(("recovery", "running", "sleep", "stress", "strength", "nutrition")),
+        min_size=1, max_size=6, unique=True,
+    ),
+)
+def test_run_synthesis_twice_produces_equal_state(
+    tmp_path_factory, domains: list[str],
+):
+    # Each Hypothesis example gets a fresh tmp DB so runs don't
+    # interfere. max_examples is small because a full run_synthesis
+    # cycle is ~10ms + two DB setups.
+    tmp_path = tmp_path_factory.mktemp("prop")
+    db_path = tmp_path / "state.db"
+    initialize_database(db_path)
+
+    proposals = [_make_proposal(d, i + 1) for i, d in enumerate(domains)]
+
+    # First synthesis.
+    conn = open_connection(db_path)
+    try:
+        for p in proposals:
+            project_proposal(conn, p)
+        run_synthesis(
+            conn, for_date=FOR_DATE, user_id=USER,
+            snapshot=_stressful_snapshot(),
+        )
+        snap_first = _snapshot_db(conn)
+    finally:
+        conn.close()
+
+    # Second synthesis — canonical-plan replacement. Proposals already
+    # exist (idempotent projection), so we just call run_synthesis
+    # again.
+    conn = open_connection(db_path)
+    try:
+        run_synthesis(
+            conn, for_date=FOR_DATE, user_id=USER,
+            snapshot=_stressful_snapshot(),
+        )
+        snap_second = _snapshot_db(conn)
+    finally:
+        conn.close()
+
+    # After stripping volatile columns, the two snapshots must be equal.
+    assert snap_first == snap_second, (
+        "run_synthesis produced divergent persisted state across two runs"
+    )

--- a/safety/tests/property/test_synthesis_policy_properties.py
+++ b/safety/tests/property/test_synthesis_policy_properties.py
@@ -1,0 +1,315 @@
+"""M7 — Hypothesis property tests for ``synthesis_policy``.
+
+Every assertion here pins a runtime invariant that was previously only
+exercised by example-based tests. A Hypothesis counter-example means
+the invariant is broken somewhere the example suite doesn't reach.
+
+Seed control: ``@settings(derandomize=True)`` on every strategy so CI
+runs are reproducible. Max-examples is kept modest (100) — these
+tests are fast enough to run in the main suite without gating.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+
+try:
+    from hypothesis import given, settings, strategies as st
+except ImportError:  # pragma: no cover — hypothesis is a dev-only dep
+    pytest.skip("hypothesis not installed", allow_module_level=True)
+
+from health_agent_infra.core.synthesis_policy import (
+    PHASE_A_EVALUATORS,
+    PHASE_B_TARGETS,
+    XRuleFiring,
+    XRuleWriteSurfaceViolation,
+    apply_phase_a,
+    apply_phase_b,
+    evaluate_phase_a,
+    guard_phase_b_mutation,
+)
+
+
+DOMAINS = ("recovery", "running", "strength", "sleep", "stress", "nutrition")
+PHASE_A_TIERS = ("soften", "block", "cap_confidence")
+HARD_ACTIONS_BY_DOMAIN = {
+    "recovery": "proceed_with_planned_session",
+    "running": "proceed_with_planned_run",
+    "strength": "proceed_with_planned_session",
+    "sleep": "maintain_schedule",
+    "stress": "maintain_routine",
+    "nutrition": "maintain_targets",
+}
+
+
+def _proposal_strategy() -> st.SearchStrategy[dict[str, Any]]:
+    """A random-ish proposal dict that's valid enough to feed apply_phase_a.
+
+    Keeps the payload shape stable; only the domain + action + confidence
+    vary. Fields outside synthesis's read-set are fixed so random data
+    doesn't send the test down an irrelevant control path.
+    """
+
+    return st.builds(
+        lambda domain, confidence: {
+            "domain": domain,
+            "action": HARD_ACTIONS_BY_DOMAIN[domain],
+            "action_detail": None,
+            "confidence": confidence,
+            "rationale": ["x"],
+            "uncertainty": [],
+        },
+        domain=st.sampled_from(DOMAINS),
+        confidence=st.sampled_from(("low", "moderate", "high")),
+    )
+
+
+def _firing_strategy(
+    rule_id: str = "X_prop",
+    tier: str = "soften",
+) -> st.SearchStrategy[XRuleFiring]:
+    return st.builds(
+        XRuleFiring,
+        rule_id=st.just(rule_id),
+        tier=st.just(tier),
+        affected_domain=st.sampled_from(DOMAINS),
+        trigger_note=st.just("synthetic"),
+        recommended_mutation=st.just({
+            "action": "downgrade_hard_session_to_zone_2",
+            "action_detail": {"reason_token": "prop_test"},
+        }),
+        source_signals=st.just({}),
+        phase=st.just("A"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — block dominates soften on the same domain
+# ---------------------------------------------------------------------------
+
+
+@settings(derandomize=True, max_examples=100)
+@given(
+    proposal=_proposal_strategy(),
+    n_softens=st.integers(min_value=0, max_value=5),
+    n_blocks=st.integers(min_value=1, max_value=5),  # at least one block
+)
+def test_block_always_dominates_soften_on_same_proposal(
+    proposal: dict[str, Any], n_softens: int, n_blocks: int,
+):
+    domain = proposal["domain"]
+    firings: list[XRuleFiring] = []
+    for _ in range(n_softens):
+        firings.append(XRuleFiring(
+            rule_id="X_s", tier="soften", affected_domain=domain,
+            trigger_note="s", recommended_mutation={
+                "action": "downgrade_hard_session_to_zone_2",
+                "action_detail": {"reason_token": "soften"},
+            },
+            source_signals={}, phase="A",
+        ))
+    for _ in range(n_blocks):
+        firings.append(XRuleFiring(
+            rule_id="X_b", tier="block", affected_domain=domain,
+            trigger_note="b", recommended_mutation={
+                "action": "escalate_for_user_review",
+                "action_detail": {"reason_token": "block"},
+            },
+            source_signals={}, phase="A",
+        ))
+
+    mutated, fired_ids = apply_phase_a(proposal, firings)
+
+    # Block wins: the final action is the block's escalate.
+    assert mutated["action"] == "escalate_for_user_review"
+    # Every soften + block is still recorded as fired (audit completeness).
+    assert "X_s" in fired_ids or n_softens == 0
+    assert "X_b" in fired_ids
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — cap_confidence commutes with soften/block
+# ---------------------------------------------------------------------------
+
+
+@settings(derandomize=True, max_examples=50)
+@given(
+    proposal=_proposal_strategy().filter(lambda p: p["confidence"] == "high"),
+    order=st.sampled_from(["cap_first", "block_first"]),
+)
+def test_cap_confidence_commutes_with_block(
+    proposal: dict[str, Any], order: str,
+):
+    """Applying block then cap in either order ends up at the same state:
+    action escalated AND confidence dropped from high to moderate."""
+
+    domain = proposal["domain"]
+    cap = XRuleFiring(
+        rule_id="X7", tier="cap_confidence", affected_domain=domain,
+        trigger_note="stress", recommended_mutation=None,
+        source_signals={}, phase="A",
+    )
+    block = XRuleFiring(
+        rule_id="X1b", tier="block", affected_domain=domain,
+        trigger_note="sleep", recommended_mutation={
+            "action": "escalate_for_user_review",
+            "action_detail": {"reason_token": "block"},
+        },
+        source_signals={}, phase="A",
+    )
+
+    order_a = [cap, block] if order == "cap_first" else [block, cap]
+    order_b = list(reversed(order_a))
+
+    mutated_a, _ = apply_phase_a(proposal, order_a)
+    mutated_b, _ = apply_phase_a(proposal, order_b)
+
+    assert mutated_a["action"] == mutated_b["action"] == "escalate_for_user_review"
+    assert mutated_a["confidence"] == mutated_b["confidence"] == "moderate"
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — copy-on-write: input dict not mutated
+# ---------------------------------------------------------------------------
+
+
+@settings(derandomize=True, max_examples=50)
+@given(proposal=_proposal_strategy())
+def test_apply_phase_a_does_not_mutate_input_proposal(
+    proposal: dict[str, Any],
+):
+    snapshot_before = copy.deepcopy(proposal)
+    firings = [XRuleFiring(
+        rule_id="X_s", tier="soften",
+        affected_domain=proposal["domain"],
+        trigger_note="s",
+        recommended_mutation={
+            "action": "downgrade_hard_session_to_zone_2",
+            "action_detail": {"reason_token": "test"},
+        },
+        source_signals={}, phase="A",
+    )]
+    apply_phase_a(proposal, firings)
+    assert proposal == snapshot_before
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — Phase B guard rejects every off-surface mutation
+# ---------------------------------------------------------------------------
+
+
+@settings(derandomize=True, max_examples=80)
+@given(
+    rule_id=st.sampled_from(list(PHASE_B_TARGETS.keys())),
+    domain=st.sampled_from(DOMAINS),
+    mutation_shape=st.sampled_from(["action_only", "action_and_detail", "no_detail"]),
+)
+def test_guard_phase_b_rejects_action_mutations(
+    rule_id: str, domain: str, mutation_shape: str,
+):
+    # Build a mutation that's *always* off-surface: contains 'action',
+    # which Phase B is forbidden from touching.
+    if mutation_shape == "action_only":
+        mutation = {"action": "proceed_with_planned_session"}
+    elif mutation_shape == "action_and_detail":
+        mutation = {
+            "action": "proceed_with_planned_session",
+            "action_detail": {"k": "v"},
+        }
+    else:
+        mutation = {"action": "proceed_with_planned_session"}
+
+    firing = XRuleFiring(
+        rule_id=rule_id, tier="adjust", affected_domain=domain,
+        trigger_note="off-surface attempt",
+        recommended_mutation=mutation,
+        source_signals={}, phase="B",
+    )
+    with pytest.raises(XRuleWriteSurfaceViolation):
+        guard_phase_b_mutation(firing)
+
+
+@settings(derandomize=True, max_examples=60)
+@given(
+    rule_id=st.sampled_from(list(PHASE_B_TARGETS.keys())),
+    off_target_domain=st.sampled_from(DOMAINS),
+)
+def test_guard_phase_b_rejects_off_target_domain(
+    rule_id: str, off_target_domain: str,
+):
+    allowed = PHASE_B_TARGETS[rule_id]
+    if off_target_domain in allowed:
+        # Hypothesis may sample an allowed domain; the sibling test
+        # covers the rejection path.
+        return
+    firing = XRuleFiring(
+        rule_id=rule_id, tier="adjust",
+        affected_domain=off_target_domain,
+        trigger_note="wrong domain",
+        recommended_mutation={"action_detail": {"k": "v"}},
+        source_signals={}, phase="B",
+    )
+    with pytest.raises(XRuleWriteSurfaceViolation):
+        guard_phase_b_mutation(firing)
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — evaluate_phase_a only emits firings for proposal domains
+# ---------------------------------------------------------------------------
+
+
+@settings(derandomize=True, max_examples=25)
+@given(proposals=st.lists(_proposal_strategy(), min_size=1, max_size=6))
+def test_evaluate_phase_a_emits_only_for_proposal_domains(proposals):
+    # An "everything triggers" snapshot so every rule that *can* fire
+    # does fire. The property under test is not whether rules fire,
+    # but that firings reference only domains present in proposals.
+    snapshot = {
+        "recovery": {
+            "classified_state": {"sleep_debt_band": "moderate"},
+            "today": {"acwr_ratio": 1.6},
+        },
+        "sleep": {"classified_state": {"sleep_debt_band": "moderate"}},
+        "stress": {
+            "classified_state": {"garmin_stress_band": "very_high"},
+            "today": {"body_battery_end_of_day": 10},
+            "today_body_battery": 10,
+            "today_garmin": 85,
+        },
+    }
+    thresholds = {
+        "synthesis": {"x_rules": {
+            "x1a": {"sleep_debt_trigger_band": "moderate"},
+            "x1b": {"sleep_debt_trigger_band": "elevated"},
+            "x2": {"deficit_kcal_min": 500.0, "protein_ratio_max": 0.7},
+            "x3a": {"acwr_ratio_lower": 1.3, "acwr_ratio_upper": 1.5},
+            "x3b": {"acwr_ratio_min": 1.5},
+            "x4": {"heavy_lower_body_min_volume": 2000.0},
+            "x5": {"vigorous_intensity_min": 20, "long_run_min_duration_s": 4500},
+            "x6a": {"body_battery_max": 30},
+            "x6b": {"body_battery_max": 15},
+            "x7": {
+                "stress_trigger_bands": ["high", "very_high"],
+                "moderate_min_score": 40, "high_min_score": 60, "very_high_min_score": 80,
+            },
+        }},
+        "classify": {"nutrition": {"targets": {
+            "calorie_target_kcal": 2400, "protein_target_g": 140,
+        }}},
+    }
+
+    firings = evaluate_phase_a(proposals, thresholds=thresholds, snapshot=snapshot) \
+        if False else [
+        f for evaluator in PHASE_A_EVALUATORS
+        for f in evaluator(snapshot, proposals, thresholds)
+    ]
+
+    proposal_domains = {p["domain"] for p in proposals}
+    for f in firings:
+        assert f.affected_domain in proposal_domains, (
+            f"evaluator emitted orphan firing for {f.affected_domain!r} "
+            f"(rule {f.rule_id}); proposal domains were {sorted(proposal_domains)}"
+        )

--- a/safety/tests/test_migrations_roundtrip.py
+++ b/safety/tests/test_migrations_roundtrip.py
@@ -1,0 +1,212 @@
+"""M7 — migration + reproject round-trip.
+
+Two invariants:
+
+  1. ``initialize_database`` applied from scratch on two independent
+     fresh DB files produces byte-equal schema + identical
+     ``schema_migrations`` rows (modulo the auto-stamped
+     ``applied_at`` timestamp). Pins "migrations are deterministic."
+
+  2. Given a JSONL audit trail produced on DB1 via the CLI-level
+     writeback + review flow, reprojecting that trail onto a second
+     fresh DB reproduces identical ``recommendation_log`` /
+     ``review_event`` / ``review_outcome`` rows (modulo the
+     ``projected_at`` timestamp). This is what makes the JSONL the
+     durable boundary it's documented to be.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from health_agent_infra.core.review.outcomes import (
+    record_review_outcome,
+    schedule_review,
+)
+from health_agent_infra.core.schemas import (
+    FollowUp,
+    PolicyDecision,
+    RECOMMENDATION_SCHEMA_VERSION,
+    ReviewEvent,
+)
+from health_agent_infra.core.state import (
+    initialize_database,
+    open_connection,
+    project_recommendation,
+    project_review_event,
+    project_review_outcome,
+    reproject_from_jsonl,
+)
+from health_agent_infra.core.writeback.recommendation import (
+    ALLOWED_RELATIVE_ROOT,
+    perform_writeback,
+)
+from health_agent_infra.domains.recovery.schemas import TrainingRecommendation
+
+
+USER = "u_rt"
+FOR_DATE = date(2026, 4, 17)
+ISSUED_AT = datetime(2026, 4, 17, 6, 30, tzinfo=timezone.utc)
+REVIEW_AT = datetime(2026, 4, 18, 7, 0, tzinfo=timezone.utc)
+RECORDED_AT = datetime(2026, 4, 18, 19, 0, tzinfo=timezone.utc)
+
+
+# Columns the write path stamps with wall-clock time. They legitimately
+# diverge between DB1 and DB2 and must be excluded from equality checks.
+_VOLATILE_COLUMNS: frozenset[str] = frozenset({
+    "projected_at",
+    "applied_at",
+    "validated_at",
+    "outcome_id",  # autoincrement, per-DB
+    "jsonl_offset",  # reproject assigns sequential line numbers; different runs may differ
+})
+
+
+def _build_recommendation() -> TrainingRecommendation:
+    return TrainingRecommendation(
+        schema_version=RECOMMENDATION_SCHEMA_VERSION,
+        recommendation_id=f"rec_{FOR_DATE.isoformat()}_{USER}_recovery",
+        user_id=USER,
+        issued_at=ISSUED_AT,
+        for_date=FOR_DATE,
+        action="proceed_with_planned_session",
+        action_detail=None,
+        rationale=["sleep=normal", "hrv=baseline"],
+        confidence="high",
+        uncertainty=[],
+        follow_up=FollowUp(
+            review_at=REVIEW_AT,
+            review_question="Did today feel appropriate?",
+            review_event_id=f"rev_{FOR_DATE.isoformat()}_{USER}_recovery",
+        ),
+        policy_decisions=[
+            PolicyDecision(rule_id="r1", decision="allow", note="ok"),
+        ],
+        bounded=True,
+    )
+
+
+def _seed_db_from_jsonl_sources(
+    db_path: Path,
+    recommendation: TrainingRecommendation,
+    base_dir: Path,
+) -> None:
+    """Seed DB1 the way the CLI does: perform_writeback emits JSONL +
+    project into DB; schedule + record review → JSONL + project."""
+
+    initialize_database(db_path)
+    perform_writeback(recommendation, base_dir=base_dir, now=ISSUED_AT)
+
+    conn = open_connection(db_path)
+    try:
+        project_recommendation(conn, recommendation)
+    finally:
+        conn.close()
+
+    event = schedule_review(recommendation, base_dir=base_dir, domain="recovery")
+    outcome = record_review_outcome(
+        event,
+        base_dir=base_dir,
+        followed_recommendation=True,
+        self_reported_improvement=True,
+        free_text="felt good",
+        now=RECORDED_AT,
+    )
+
+    conn = open_connection(db_path)
+    try:
+        project_review_event(conn, event)
+        project_review_outcome(conn, outcome)
+    finally:
+        conn.close()
+
+
+def _strip(row: sqlite3.Row) -> dict:
+    out = {k: row[k] for k in row.keys() if k not in _VOLATILE_COLUMNS}
+    # payload_json carries no wall-clock fields that diverge here; keep it.
+    return out
+
+
+def _snapshot_audit_tables(conn: sqlite3.Connection) -> dict[str, list[dict]]:
+    snap: dict[str, list[dict]] = {}
+    for table in ("recommendation_log", "review_event", "review_outcome"):
+        rows = conn.execute(
+            f"SELECT * FROM {table} ORDER BY 1"  # noqa: S608 — fixed list
+        ).fetchall()
+        snap[table] = [_strip(r) for r in rows]
+    return snap
+
+
+# ---------------------------------------------------------------------------
+# Migration determinism
+# ---------------------------------------------------------------------------
+
+
+def test_two_fresh_dbs_have_identical_schema_and_migration_bookkeeping(tmp_path):
+    db_a = tmp_path / "a.db"
+    db_b = tmp_path / "b.db"
+    initialize_database(db_a)
+    initialize_database(db_b)
+
+    def _schema(conn: sqlite3.Connection) -> list[tuple[str, str]]:
+        rows = conn.execute(
+            "SELECT type, name, sql FROM sqlite_master "
+            "WHERE name NOT LIKE 'sqlite_%' "
+            "ORDER BY type, name"
+        ).fetchall()
+        return [(r["type"], r["name"], r["sql"] or "") for r in rows]
+
+    def _migrations(conn: sqlite3.Connection) -> list[tuple]:
+        rows = conn.execute(
+            "SELECT version, filename FROM schema_migrations ORDER BY version"
+        ).fetchall()
+        return [tuple(r) for r in rows]
+
+    conn_a = open_connection(db_a)
+    conn_b = open_connection(db_b)
+    try:
+        assert _schema(conn_a) == _schema(conn_b)
+        assert _migrations(conn_a) == _migrations(conn_b)
+    finally:
+        conn_a.close()
+        conn_b.close()
+
+
+# ---------------------------------------------------------------------------
+# JSONL → reproject round trip
+# ---------------------------------------------------------------------------
+
+
+def test_jsonl_reproject_onto_fresh_db_matches_original(tmp_path):
+    base_dir = tmp_path / ALLOWED_RELATIVE_ROOT
+    db_one = tmp_path / "one.db"
+    db_two = tmp_path / "two.db"
+
+    recommendation = _build_recommendation()
+    _seed_db_from_jsonl_sources(db_one, recommendation, base_dir)
+
+    initialize_database(db_two)
+    conn_two = open_connection(db_two)
+    try:
+        # Reproject from DB1's JSONL trail.
+        reproject_from_jsonl(conn_two, base_dir)
+    finally:
+        conn_two.close()
+
+    conn_one = open_connection(db_one)
+    conn_two = open_connection(db_two)
+    try:
+        snap_one = _snapshot_audit_tables(conn_one)
+        snap_two = _snapshot_audit_tables(conn_two)
+    finally:
+        conn_one.close()
+        conn_two.close()
+
+    assert snap_one == snap_two, (
+        "reproject-from-JSONL did not reconstruct the same audit rows"
+    )

--- a/safety/tests/test_synthesis_concurrency.py
+++ b/safety/tests/test_synthesis_concurrency.py
@@ -1,0 +1,149 @@
+"""M7 — synthesis concurrency invariants.
+
+Two threads call ``run_synthesis`` for the same ``(for_date, user_id)``
+against the same DB file. SQLite's ``BEGIN IMMEDIATE`` (the guard the
+synthesis transaction uses) must make exactly one winner: the other
+thread either rolls back or queues. Final state must be consistent —
+exactly one canonical plan, referenced by exactly one set of
+recommendations / firings.
+
+The contract is "whoever gets to commit first wins cleanly; the loser
+does not partial-write." Which of the two wins is not specified —
+either ordering is valid.
+"""
+
+from __future__ import annotations
+
+import queue
+import sqlite3
+import threading
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from health_agent_infra.core.schemas import canonical_daily_plan_id
+from health_agent_infra.core.state import (
+    initialize_database,
+    open_connection,
+    project_proposal,
+)
+from health_agent_infra.core.synthesis import run_synthesis
+from health_agent_infra.core.writeback.proposal import PROPOSAL_SCHEMA_VERSIONS
+
+
+FOR_DATE = date(2026, 4, 17)
+USER = "u_conc"
+
+
+def _proposal() -> dict[str, Any]:
+    return {
+        "schema_version": PROPOSAL_SCHEMA_VERSIONS["recovery"],
+        "proposal_id": f"prop_{FOR_DATE}_{USER}_recovery_01",
+        "user_id": USER,
+        "for_date": FOR_DATE.isoformat(),
+        "domain": "recovery",
+        "action": "proceed_with_planned_session",
+        "action_detail": None,
+        "rationale": ["x"],
+        "confidence": "high",
+        "uncertainty": [],
+        "policy_decisions": [{"rule_id": "r1", "decision": "allow", "note": "n"}],
+        "bounded": True,
+    }
+
+
+def _quiet_snapshot() -> dict[str, Any]:
+    return {
+        "recovery": {
+            "classified_state": {"sleep_debt_band": "none"},
+            "today": {"acwr_ratio": 1.0},
+        },
+        "running": {},
+    }
+
+
+def test_two_threads_synthesising_same_day_produce_consistent_final_state(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "state.db"
+    initialize_database(db_path)
+
+    conn = open_connection(db_path)
+    try:
+        project_proposal(conn, _proposal())
+    finally:
+        conn.close()
+
+    # Two threads, each opening its own connection + calling
+    # run_synthesis. A barrier makes sure both get to the write
+    # transaction at the same time, maximising the chance of a lock
+    # collision.
+    barrier = threading.Barrier(2)
+    results: queue.Queue = queue.Queue()
+
+    def _runner():
+        barrier.wait()
+        conn = open_connection(db_path)
+        # Short busy timeout: we want the loser to either fail fast or
+        # queue briefly — not wait minutes on a test.
+        conn.execute("PRAGMA busy_timeout = 2000")
+        try:
+            run_synthesis(
+                conn, for_date=FOR_DATE, user_id=USER,
+                snapshot=_quiet_snapshot(),
+            )
+            results.put(("ok", None))
+        except sqlite3.OperationalError as exc:
+            results.put(("locked", str(exc)))
+        except Exception as exc:  # noqa: BLE001 — surface any other failure
+            results.put(("error", f"{type(exc).__name__}: {exc}"))
+        finally:
+            conn.close()
+
+    t1 = threading.Thread(target=_runner)
+    t2 = threading.Thread(target=_runner)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    outcomes = [results.get() for _ in range(2)]
+    statuses = [o[0] for o in outcomes]
+
+    # Acceptable: both succeed (one queued behind the other via the
+    # busy_timeout), or one wins and the other reports "locked". What's
+    # NOT acceptable is an 'error' (e.g. inconsistency exception).
+    assert "error" not in statuses, f"unexpected error outcomes: {outcomes}"
+
+    # Post-condition: regardless of ordering, the DB has exactly one
+    # canonical plan row for this (for_date, user_id) and its
+    # recommendations are consistent (non-empty, all point to the same
+    # plan id).
+    canonical_id = canonical_daily_plan_id(FOR_DATE, USER)
+    conn = open_connection(db_path)
+    try:
+        plans = conn.execute(
+            "SELECT daily_plan_id FROM daily_plan WHERE user_id = ? "
+            "AND for_date = ?",
+            (USER, FOR_DATE.isoformat()),
+        ).fetchall()
+        assert len(plans) == 1, (
+            f"expected exactly one canonical plan after two concurrent "
+            f"synthesis calls; found {[dict(p) for p in plans]}"
+        )
+        assert plans[0]["daily_plan_id"] == canonical_id
+
+        rec_plans = conn.execute(
+            "SELECT DISTINCT daily_plan_id FROM recommendation_log "
+            "WHERE user_id = ? AND for_date = ? AND daily_plan_id IS NOT NULL",
+            (USER, FOR_DATE.isoformat()),
+        ).fetchall()
+        assert len(rec_plans) == 1, (
+            f"recommendations reference multiple plans: "
+            f"{[dict(r) for r in rec_plans]}"
+        )
+        assert rec_plans[0]["daily_plan_id"] == canonical_id
+    finally:
+        conn.close()

--- a/uv.lock
+++ b/uv.lock
@@ -319,6 +319,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "build" },
+    { name = "hypothesis" },
     { name = "pytest" },
 ]
 
@@ -326,12 +327,25 @@ dev = [
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2" },
     { name = "garminconnect", specifier = ">=0.2" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "keyring", specifier = ">=24.0" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "platformdirs", specifier = ">=4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "hypothesis"
+version = "6.152.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/b1/c32bcddb9aab9e3abc700f1f56faf14e7655c64a16ca47701a57362276ea/hypothesis-6.152.1.tar.gz", hash = "sha256:4f4ed934eee295dd84ee97592477d23e8dc03e9f12ae0ee30a4e7c9ef3fca3b0", size = 465029, upload-time = "2026-04-14T22:29:24.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl", hash = "sha256:40a3619d9e0cb97b018857c7986f75cf5de2e5ec0fa8a0b172d00747758f749e", size = 530752, upload-time = "2026-04-14T22:29:20.893Z" },
+]
 
 [[package]]
 name = "idna"
@@ -734,6 +748,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `hypothesis` to dev extras; converts implicit synthesis-policy invariants into 6 executable properties (block>soften precedence, cap_confidence commutes with block, copy-on-write input preservation, Phase B write-surface guard, domain-scoped firings).
- Adds a synthesis idempotency property: re-running `run_synthesis` on byte-equal inputs produces byte-equal persisted rows across every synthesis table (modulo volatile timestamps / autoincrements).
- Migration round-trip test: two `initialize_database` calls produce identical schema + bookkeeping, and JSONL reproject onto a fresh DB reconstructs identical `recommendation_log` / `review_event` / `review_outcome` rows. Pins "JSONL is the durable boundary."
- Concurrency test: two threads calling `run_synthesis` for the same `(for_date, user_id)` land one canonical plan + consistent recommendation linkage.

## Test plan
- [x] `uv run pytest safety/tests -q` — 1402 passing
- [x] Property strategies use `settings(derandomize=True)` for CI stability; `max_examples` kept modest so suite stays fast
- [x] No runtime behavior change — M7 is tests-only

## Notes
- `uv.lock` bumps for the new dep.