### PR TITLE
Phase A: onboarding UX + local telemetry + v0.1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,56 @@
 # Health Agent Infra
 
-**Health Agent Infra is a governed, agent-operable runtime for a
-multi-domain personal health agent.** One Claude agent reads a
-cross-domain state snapshot, emits per-domain proposals via domain
-skills, and a synthesis skill reconciles them via codified
-cross-domain rules into bounded per-domain recommendations validated
-at atomic commit. Every CLI subcommand carries machine-readable
-contract metadata (mutation class, idempotency, exit codes) that an
-agent reads via ``hai capabilities --json``; an authoritative
-``intent-router`` skill maps natural-language intent to deterministic
-workflows against that contract. Every X-rule firing carries both a
-stable slug and a sentence-form explanation an agent can narrate
-verbatim.
+**A governed local agent runtime for personal health data.**
+Claude Code + Garmin today; MCP-portable and multi-source on the roadmap.
 
-Its source of truth is a **local SQLite database on the user's
-device**. That local state persists accepted daily state, proposal
-history, synthesized plans, final recommendations, and review
-outcomes across days, so the agent resumes from runtime state
-rather than from chat memory alone.
+A Claude Code agent reads your own health data, emits per-domain proposals
+bounded by codified rules, and commits auditable recommendations you review
+the next day. Every decision is logged to a local SQLite database on your
+machine; nothing leaves your device.
 
-It is not a chatbot, a wearable API, a general AI health app, or a
-clinical product. It is infrastructure the agent consumes:
-**deterministic Python tools** that ingest evidence, classify state,
-apply policy, run synthesis, and persist recommendations, plus
-**markdown skills** that instruct the agent in how to compose
-rationale and surface uncertainty once actions are mechanically
-constrained.
+**For** technical users comfortable with a CLI who use Claude Code and want
+agent recommendations they can audit, reproduce, and keep local.
 
-- Python = tools (data acquisition, projection, band classification,
-  R-rule + X-rule evaluation, schema validation, atomic
-  transactions, evals).
-- Markdown = skills (judgment: picking from an already-constrained
-  action set, composing rationale, surfacing uncertainty).
-- The code-vs-skill boundary is tight and the plan documents it.
-  Skills never change an action; code never writes prose.
+- **Local-first.** State lives in a SQLite file under your home directory. No
+  cloud, no account, no remote telemetry.
+- **Governed, not generative.** Python owns mechanical decisions
+  (classification bands, policy rules, transactional commits); markdown
+  skills own rationale and uncertainty. Skills never change an action; code
+  never writes prose.
+- **Agent-operable by contract.** Every CLI subcommand carries
+  machine-readable contract metadata (mutation class, idempotency, exit
+  codes) that an agent reads via `hai capabilities --json`. An authoritative
+  `intent-router` skill maps natural-language intent to deterministic
+  workflows; every X-rule firing carries a stable slug plus a sentence-form
+  explanation the agent can narrate verbatim.
+- **Auditable by construction.** Pulls, proposals, rule firings, synthesis,
+  and final recommendations all land in typed tables. Inspect anytime with
+  `hai doctor`, `hai explain`, `hai stats`, or plain SQL.
+
+## Install
+
+```bash
+pipx install health-agent-infra                      # or: pip install -e .
+hai init --with-auth --with-first-pull               # scaffolds state + config + skills,
+                                                     # prompts for Garmin credentials,
+                                                     # backfills the last 7 days
+hai daily                                            # tomorrow morning: pull → clean → propose → synthesize → commit
+hai stats                                            # local funnel: syncs, recent runs, daily streak
+```
+
+Prefer the non-interactive path? Run `hai init` on its own, then `hai auth
+garmin` separately. `hai init` is idempotent and safe to re-run. Full CLI
+surface in
+[`reporting/docs/agent_cli_contract.md`](reporting/docs/agent_cli_contract.md).
 
 ## Six domains in v1
 
-recovery · running · sleep · stress · strength · nutrition
+**recovery · running · sleep · stress · strength · nutrition**
 
-Each ships per-domain schemas, classify, policy, a readiness skill,
-and is wired into the synthesis X-rule catalogue. Nutrition is
-macros-only in v1 (no meal-level / food taxonomy / micronutrient
-inference) per the Phase 2.5 retrieval-gate outcome — see
-[``reporting/docs/non_goals.md``](reporting/docs/non_goals.md).
+Each domain ships its own schemas, classification bands, policy rules, and a
+readiness skill, and is wired into the synthesis X-rule catalogue that
+reconciles across domains. Nutrition is macros-only in v1 — see
+[`reporting/docs/non_goals.md`](reporting/docs/non_goals.md).
 
 ## Local-first runtime at a glance
 
@@ -77,82 +84,50 @@ pull / intake  →  projectors  →  accepted_*_state_daily tables
              hai review schedule / record / summary
 ```
 
-- **Local state memory** — ``accepted_*_state_daily`` tables store
-  the canonical per-domain day-level state the runtime reasons over.
+- **Local state memory** — ``accepted_*_state_daily`` tables store the
+  canonical per-domain day-level state the runtime reasons over.
 - **Decision memory** — ``proposal_log`` (per-domain planned intent),
-  ``planned_recommendation`` (aggregate pre-X-rule plan),
-  ``daily_plan`` + ``x_rule_firing`` + ``recommendation_log``
-  (aggregate adapted plan) preserve the full audit chain: what was
-  originally planned, how X-rules mutated it, and what was finally
-  committed.
-- **Outcome memory** — ``review_event`` and ``review_outcome``
-  record how the plan went, so the history of decisions and outcomes
-  stays on-device.
+  ``planned_recommendation`` (aggregate pre-X-rule plan), ``daily_plan`` +
+  ``x_rule_firing`` + ``recommendation_log`` (aggregate adapted plan)
+  preserve the full audit chain: what was originally planned, how X-rules
+  mutated it, and what was finally committed.
+- **Outcome memory** — ``review_event`` and ``review_outcome`` record how
+  the plan went, so the history of decisions and outcomes stays on-device.
 - **Agent contract surface** — ``hai capabilities --json`` emits a
-  machine-readable manifest of every subcommand; the markdown mirror
-  lives at
+  machine-readable manifest of every subcommand; the markdown mirror lives
+  at
   [``reporting/docs/agent_cli_contract.md``](reporting/docs/agent_cli_contract.md).
-  The ``intent-router`` skill is authoritative for NL → CLI mapping
-  against that contract.
+  The ``intent-router`` skill is authoritative for NL → CLI mapping against
+  that contract.
 
-See [``reporting/docs/architecture.md``](reporting/docs/architecture.md)
-for the full pipeline + code-vs-skill boundary.
+See [`reporting/docs/architecture.md`](reporting/docs/architecture.md) for
+the full pipeline and the code-vs-skill boundary.
 
-## Install
+## Roadmap
 
-```bash
-pip install -e .              # local editable install
-# or: pip install health-agent-infra
-hai setup-skills              # copies skills into ~/.claude/skills/
-hai state init                # creates the local on-device memory store
-hai --help
-```
+- **Runtime portability via MCP.** Expose the agent-safe CLI surface as an
+  MCP server so any agentic runtime (Claude Code, Codex, others) can drive
+  it. Today the project is Claude Code–native; the CLI contract is already
+  annotated agent-safe vs. interactive, which maps cleanly onto MCP tool
+  schemas.
+- **Multi-source wearables.** Apple Health, Oura, Whoop. The adapter
+  protocol (`core/pull/protocol.py`) is already source-agnostic; the
+  per-domain evidence contract needs to broaden before additional sources
+  land. Community adapters welcome — see
+  [`reporting/docs/how_to_add_a_pull_adapter.md`](reporting/docs/how_to_add_a_pull_adapter.md).
+- **Skill-narration eval harness.** Live-mode pilot shipped (Phase E +
+  M8 Phase 4); broader scenario coverage still to come. See
+  `safety/evals/skill_harness_blocker.md`.
 
-## CLI surface
+## What this is not
 
-```
-# Evidence + intake
-hai pull [--live] --date <d>                   # Garmin CSV / live pull
-hai clean --evidence-json <p>                  # raw → CleanedEvidence + RawSummary
-hai intake gym|exercise|nutrition|stress|note|readiness ...
+- Not a medical device, not hosted, not multi-user, not an ML loop. See
+  [`reporting/docs/non_goals.md`](reporting/docs/non_goals.md).
+- Not meal-level nutrition in v1 — macros only.
+- Not an MCP server yet (see Roadmap).
+- Not an MCP-wrapper-integrated or skill-harness-eval-complete release yet.
 
-# State
-hai state init | migrate | read | snapshot | reproject
-
-# Per-domain debug
-hai classify --domain <d> --evidence-json <p>
-hai policy   --domain <d> --evidence-json <p>
-
-# Agent flow
-hai propose  --domain <d> --proposal-json <p>
-hai synthesize --as-of <d> --user-id <u>
-hai daily                                      # morning orchestrator (pull→clean→reproject→propose→synthesize)
-
-# Persistence + review
-hai writeback --recommendation-json <p>  # recovery-only legacy direct path
-hai review schedule | record | summary [--domain <d>]
-
-# Agent contract + audit
-hai capabilities [--markdown]                  # JSON manifest (or regenerate the contract doc)
-hai explain --for-date <d> --user-id <u>       # three-state audit: planned → adapted → performed
-hai memory set | list | archive                # explicit user memory (goals, preferences, constraints)
-
-# Ops
-hai doctor [--json]                            # runtime health + per-source freshness
-hai init                                       # interactive first-run wizard
-
-# Auth + config + helpers
-hai auth garmin | status
-hai config init | show
-hai exercise search --query <free-text>
-
-# Evals
-hai eval run --domain <d> | --synthesis [--json]
-
-hai setup-skills                               # copy 14 packaged skills into ~/.claude/skills/
-```
-
-## Read this repo in 5 minutes
+## Dig deeper
 
 1. **Positioning & role map** — [`reporting/docs/personal_health_agent_positioning.md`](reporting/docs/personal_health_agent_positioning.md)
 2. **Query taxonomy** — [`reporting/docs/query_taxonomy.md`](reporting/docs/query_taxonomy.md)
@@ -169,11 +144,55 @@ hai setup-skills                               # copy 14 packaged skills into ~/
 13. **Agent-operable runtime plan (M8 cycle)** — [`reporting/plans/agent_operable_runtime_plan.md`](reporting/plans/agent_operable_runtime_plan.md)
 14. **Eval capture** — [`reporting/artifacts/flagship_loop_proof/2026-04-18-multi-domain-evals/`](reporting/artifacts/flagship_loop_proof/2026-04-18-multi-domain-evals/)
 
+## CLI surface
+
+```
+# Evidence + intake
+hai pull [--live] --date <d>                   # Garmin CSV / live pull
+hai clean --evidence-json <p>                  # raw → CleanedEvidence + RawSummary
+hai intake gym|exercise|nutrition|stress|note|readiness ...
+
+# State
+hai state init | migrate | read | snapshot | reproject
+
+# Per-domain debug
+hai classify --domain <d> --evidence-json <p>
+hai policy   --domain <d> --evidence-json <p>
+
+# Agent flow (use `hai daily` for the whole loop)
+hai daily                                       # morning orchestrator (pull→clean→reproject→propose→synthesize)
+hai propose  --domain <d> --proposal-json <p>
+hai synthesize --as-of <d> --user-id <u>
+
+# Persistence + review
+hai writeback --recommendation-json <p>         # recovery-only legacy direct path
+hai review schedule | record | summary [--domain <d>]
+
+# Agent contract + audit
+hai capabilities [--markdown]                   # JSON manifest (or regenerate the contract doc)
+hai explain --for-date <d> --user-id <u>        # three-state audit: planned → adapted → performed
+hai memory set | list | archive                 # explicit user memory (goals, preferences, constraints)
+
+# Ops
+hai init [--with-auth] [--with-first-pull]      # first-run wizard (idempotent)
+hai doctor [--json]                             # runtime health + per-source freshness
+hai stats [--json]                              # local funnel (sync + command history, daily streak)
+
+# Auth + config + helpers
+hai auth garmin | status
+hai config init | show
+hai exercise search --query <free-text>
+
+# Evals
+hai eval run --domain <d> | --synthesis [--json]
+
+hai setup-skills                                # copy packaged skills into ~/.claude/skills/
+```
+
 ## Repo layout
 
-For a one-page orientation of every top-level entry (active vs
-historical vs generated) see [`REPO_MAP.md`](REPO_MAP.md). The
-package itself looks like this:
+For a one-page orientation of every top-level entry (active vs historical vs
+generated) see [`REPO_MAP.md`](REPO_MAP.md). The package itself:
 
 ```
 src/health_agent_infra/
@@ -196,62 +215,49 @@ src/health_agent_infra/
 ├── evals/                          # packaged eval runner + scenarios
 └── data/garmin/export/              # committed CSV fixture
 reporting/                          # see reporting/README.md
-├── docs/                            # architecture, x_rules, non_goals, ... (+ archive/)
-├── artifacts/flagship_loop_proof/   # eval runner captures (+ archive/, phase_0/)
+├── docs/                            # architecture, x_rules, non_goals, ...
+├── artifacts/flagship_loop_proof/   # eval runner captures
 ├── plans/                           # post-v0.1 roadmap + historical phase docs
 └── experiments/                     # frozen Phase 0.5 / 2.5 prototypes
 safety/                             # see safety/README.md
-├── tests/                           # 1459 unit + contract + integration
+├── tests/                           # 1489 unit + contract + integration
 ├── evals/                           # eval-doc reference + skill-harness pilot
-└── scripts/                         # legacy pre-rebuild demo shim (do not run)
-merge_human_inputs/                 # docs + example payloads bucket; not a Python module
+└── scripts/                         # legacy pre-rebuild demo shim
 ```
 
 ## What's proven
 
-- Six domains end-to-end: classify → policy → skill proposal →
-  synthesis → writeback → review.
-- Ten X-rule evaluators across two phases with atomic
-  transactional commits, each firing carrying a stable slug and a
-  one-sentence `human_explanation` agents can narrate verbatim.
+- Six domains end-to-end: classify → policy → skill proposal → synthesis →
+  writeback → review.
+- Ten X-rule evaluators across two phases with atomic transactional commits,
+  each firing carrying a stable slug and a one-sentence `human_explanation`
+  agents can narrate verbatim.
 - Three-state audit chain: `proposal_log` → `planned_recommendation`
   (aggregate pre-X-rule intent, migration 011) → `daily_plan` +
-  `recommendation_log` → `review_outcome`. `hai explain` renders
-  all three states from persisted rows alone.
+  `recommendation_log` → `review_outcome`. `hai explain` renders all three
+  states from persisted rows alone.
 - Agent CLI contract: every subcommand annotated with mutation class,
-  idempotency, JSON output, exit codes, agent-safe flag; machine-
-  readable manifest at `hai capabilities --json`; markdown mirror
-  at [`reporting/docs/agent_cli_contract.md`](reporting/docs/agent_cli_contract.md).
+  idempotency, JSON output, exit codes, agent-safe flag; machine-readable
+  manifest at `hai capabilities --json`; markdown mirror at
+  [`reporting/docs/agent_cli_contract.md`](reporting/docs/agent_cli_contract.md).
   Every handler on the stable exit-code taxonomy.
-- Authoritative `intent-router` skill consumes the manifest as the
-  NL → CLI mapping surface; deliberately scoped so mutation commands
-  are previewed before they run.
-- Skill-harness pilot: 7 frozen recovery scenarios, 6 with
-  hand-authored reference transcripts scoring 2.0/2.0 on the
-  token-presence rubric; live-mode backend opt-in via
-  `HAI_SKILL_HARNESS_LIVE=1`.
-- Garmin live pull via keyring (``hai auth garmin`` + ``hai pull
-  --live``).
-- Idempotent synthesis with optional ``--supersede`` versioning.
-- 28 eval scenarios (18 domain + 10 synthesis) — all deterministic
-  axes green.
-- 1459 tests covering every band, every R-rule, every X-rule,
-  atomic transaction semantics, writeback invariants, skill-boundary
-  contracts, capabilities-manifest coverage + determinism, planned-
-  ledger round-trip, three-state explain render.
-
-## What's not
-
-- Not a medical device, not hosted, not multi-user, not an ML
-  loop. See [`reporting/docs/non_goals.md`](reporting/docs/non_goals.md).
-- Not meal-level nutrition in v1.
-- Skill-narration eval harness is shipped as a pilot (Phase E +
-  M8 Phase 4) but still opt-in; live-transcript capture remains
-  operator-driven. See ``safety/evals/skill_harness_blocker.md``.
-- Not an MCP-wrapper-integrated or skill-harness-eval-complete release yet.
+- Authoritative `intent-router` skill consumes the manifest as the NL → CLI
+  mapping surface; deliberately scoped so mutation commands are previewed
+  before they run.
+- Skill-harness pilot: 7 frozen recovery scenarios, 6 with hand-authored
+  reference transcripts scoring 2.0/2.0 on the token-presence rubric;
+  live-mode backend opt-in via `HAI_SKILL_HARNESS_LIVE=1`.
+- Local onboarding + engagement telemetry (migration 012 `runtime_event_log`)
+  surfaced via `hai stats`. No data leaves the device.
+- Garmin live pull via OS keyring (`hai auth garmin` + `hai pull --live`).
+- Idempotent synthesis with optional `--supersede` versioning.
+- 28 eval scenarios (18 domain + 10 synthesis) — all deterministic axes green.
+- **1489 tests** covering every band, every R-rule, every X-rule, atomic
+  transaction semantics, writeback invariants, skill-boundary contracts,
+  capabilities-manifest coverage + determinism, planned-ledger round-trip,
+  three-state explain render, and the new runtime_event_log + hai stats
+  paths.
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md). The authoritative rebuild
-plan lives at
-``.claude/worktrees/hardcore-kare-a92e25/reporting/plans/comprehensive_rebuild_plan.md``.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "health_agent_infra"
-version = "0.1.0"
+version = "0.1.1"
 description = "Governed runtime + skills for a multi-domain personal health agent (recovery, running, sleep, stress, strength, nutrition)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/reporting/docs/agent_cli_contract.md
+++ b/reporting/docs/agent_cli_contract.md
@@ -47,7 +47,7 @@ forward-compatibility but is not currently emitted.
 
 ## Commands
 
-*36 commands; hai 0.1.0; schema agent_cli_contract.v1*
+*37 commands; hai 0.1.1; schema agent_cli_contract.v1*
 
 | Command | Mutation | Idempotent | JSON | Agent-safe | Exit codes | Description |
 |---|---|---|---|---|---|---|
@@ -85,5 +85,6 @@ forward-compatibility but is not currently emitted.
 | ``hai state read`` | ``read-only`` | ``n/a`` | ``default`` | yes | ``OK``, ``USER_INPUT`` | Read a per-domain accepted-state row for a given date. |
 | ``hai state reproject`` | ``writes-state`` | ``yes`` | ``default`` | yes | ``OK``, ``USER_INPUT`` | Rebuild the accepted_*_state_daily tables from the raw evidence JSONL. Deterministic projection — safe to re-run. |
 | ``hai state snapshot`` | ``read-only`` | ``n/a`` | ``default`` | yes | ``OK``, ``USER_INPUT`` | Emit the cross-domain state snapshot the synthesis / skills layer consumes for a (for_date, user_id) pair. |
+| ``hai stats`` | ``read-only`` | ``n/a`` | ``opt-in`` | yes | ``OK``, ``USER_INPUT`` | Summarise sync_run_log (last pull per source) + runtime_event_log (recent commands, daily streak) from the user's local DB. No telemetry leaves the device. |
 | ``hai synthesize`` | ``writes-state`` | ``yes-with-supersede`` | ``default`` | yes | ``OK``, ``USER_INPUT``, ``INTERNAL`` | Run synthesis end-to-end inside one atomic SQLite transaction: daily_plan + x_rule_firings + planned_recommendation + recommendation_log. --supersede versions the plan instead of replacing it. |
 | ``hai writeback`` | ``writes-state`` | ``no`` | ``default`` | yes | ``OK``, ``USER_INPUT`` | Legacy recovery-only direct writeback path. Validates a TrainingRecommendation against the bounded schema and appends to the recovery audit log. Non-recovery domains go through hai synthesize instead. |

--- a/reporting/docs/launch/PUBLISH_CHECKLIST.md
+++ b/reporting/docs/launch/PUBLISH_CHECKLIST.md
@@ -1,0 +1,125 @@
+# PyPI publish checklist
+
+Pre-launch state of the `health_agent_infra` package, what's already
+verified, and the exact commands to push to PyPI when you're ready.
+**Nothing here should be executed without an explicit "publish it"
+from you** — PyPI releases are visible and hard to un-ship.
+
+## Pre-flight (verified)
+
+- [x] `python -m build` produces both sdist + wheel cleanly.
+      Artifacts at `dist/health_agent_infra-0.1.0{.tar.gz,-py3-none-any.whl}`.
+- [x] `python -m twine check dist/*` → both PASSED.
+- [x] Fresh-venv wheel install works: `pipx install dist/*.whl` →
+      `hai --version` prints `hai 0.1.0`, all subcommands register
+      (including the new `hai stats`).
+- [x] `pyproject.toml` metadata:
+  - name: `health_agent_infra`
+  - version: `0.1.0`
+  - license: MIT (file: LICENSE)
+  - requires-python: `>=3.11`
+  - entry point: `hai = health_agent_infra.cli:main`
+  - classifiers: Development Status :: 4 - Beta, Console, macOS/Linux.
+- [x] Full test suite green: **1489 passed, 2 skipped** (the 2 skipped
+      are pre-existing).
+- [x] `agent_cli_contract.md` matches the auto-generated manifest
+      (test `test_committed_contract_doc_matches_generated` passes).
+
+## Pre-flight (to do before you run the publish)
+
+- [ ] Double-check no secrets or personal data in the wheel. Quick
+      audit: `unzip -l dist/*.whl | grep -iE '(secret|credential|token|api_key|\.env)'`
+      — expected output: **nothing**.
+- [ ] Verify the committed `README.md` renders correctly on PyPI.
+      Previewable with `python -m readme_renderer README.md -o /tmp/readme.html`
+      before pushing. Twine already runs this under `check`; passed.
+- [ ] Confirm the 0.1.0 version slot is unclaimed on PyPI:
+      `curl -s https://pypi.org/pypi/health_agent_infra/json | jq -r .info.version`
+      — if it returns `null` / 404, the slot is free. If it returns
+      a version, bump to `0.1.1` in `pyproject.toml` and rebuild.
+- [ ] Decide: publish to **TestPyPI first**, or go straight to PyPI?
+      TestPyPI is strongly recommended for the first release of any
+      package — it catches metadata / README-rendering issues before
+      they're permanent. See command below.
+- [ ] Have your PyPI API token ready (https://pypi.org/manage/account/token/).
+      Scope it to a project or this package only; don't use an
+      account-wide token for a CLI upload.
+
+## Commands — TestPyPI smoke (recommended first)
+
+```bash
+# 1. Upload to TestPyPI (does NOT affect the real PyPI).
+python -m twine upload --repository testpypi dist/*
+
+# 2. Install from TestPyPI in a fresh venv to verify the round-trip.
+python -m venv /tmp/testpypi_venv
+/tmp/testpypi_venv/bin/pip install \
+    --index-url https://test.pypi.org/simple/ \
+    --extra-index-url https://pypi.org/simple/ \
+    health_agent_infra
+/tmp/testpypi_venv/bin/hai --version    # expect: hai 0.1.0
+/tmp/testpypi_venv/bin/hai stats --help # expect: clean help text
+
+# 3. If anything is off, fix locally, bump to 0.1.0rc2 etc., re-upload
+#    to TestPyPI. Don't reuse a version number on PyPI itself.
+```
+
+## Commands — PyPI real publish
+
+Only after TestPyPI round-trip works, OR after deliberately skipping
+TestPyPI with full confidence in the artifacts:
+
+```bash
+# Real PyPI upload. Visible immediately at:
+#   https://pypi.org/project/health_agent_infra/
+python -m twine upload dist/*
+
+# Verify from a fresh venv with pipx:
+pipx install health-agent-infra
+hai --version           # expect: hai 0.1.0
+hai init --help         # expect: --with-auth + --with-first-pull shown
+hai stats --help        # expect: --db-path, --user-id, --limit, --json
+```
+
+## After publish
+
+- [ ] Bump `version` in `pyproject.toml` to `0.1.1-dev0` or similar so
+      local installs don't silently conflict with the published 0.1.0.
+      Commit the bump on `main`.
+- [ ] Tag the released commit: `git tag v0.1.0 && git push origin v0.1.0`.
+- [ ] Create a GitHub release from the tag with a terse changelog
+      summarising what `0.1.0` ships (the flagship loop, six domains,
+      the new `hai init --with-auth --with-first-pull`, and `hai stats`).
+- [ ] Update the README's screencast placeholder once a take exists.
+- [ ] Stage the Show HN post for the timing window you choose
+      (Tue–Thu 8–10am PT; see `show_hn_draft.md`).
+
+## If something goes wrong
+
+- **Wrong version uploaded?** You **cannot** delete and re-upload the
+  same version on PyPI. Yank it (`https://pypi.org/help/#yanked`) and
+  publish the next patch. Don't try to delete — it's a bad habit and
+  usually impossible.
+- **Broken package discovered post-publish?** Yank the broken version,
+  publish a fixed `0.1.1` as fast as possible, link the yank reason to
+  the fix version.
+- **README renders wrong on PyPI?** Fix markdown, bump version, republish.
+  Not yankable for cosmetics but not worth a panic — fix in the next
+  patch.
+
+## Decisions Dom owns before publishing
+
+- [ ] TestPyPI first, or straight to PyPI?
+      (Recommendation: TestPyPI first for first-ever release.)
+- [ ] PyPI token scope: package-scoped or account-scoped?
+      (Recommendation: package-scoped. Create after first publish if
+      the scope-to-project option isn't available before.)
+- [ ] Tag format: `v0.1.0` or `0.1.0`?
+      (Recommendation: `v` prefix — aligns with most GitHub release
+      tooling and semver convention.)
+- [ ] Announce cadence: tag → GitHub release → screencast → Show HN
+      in **one session** (higher risk, higher signal) or staged over
+      a week (safer, less momentum)?
+      (Recommendation: staged over 7 days — publish Monday, screencast
+      by Wed, Show HN Thu 9am PT. Lets the PyPI page settle before
+      traffic arrives.)

--- a/reporting/docs/launch/screencast_script.md
+++ b/reporting/docs/launch/screencast_script.md
@@ -1,0 +1,181 @@
+# 3-minute screencast — shot list + script
+
+This is the "what it looks like to install and use" demo for the top of
+the README + the launch post. Target length **2:45–3:15**. Shorter is
+better than longer; a skimmer decides in 20 seconds whether to keep
+watching.
+
+## Pre-flight (do once, before any take)
+
+- [ ] Clean macOS or Linux box (VM or a fresh user account). The demo
+      must start from "nothing installed."
+- [ ] Terminal font 16pt+ so text is legible at 720p playback.
+- [ ] Dark theme — the green "ok" / red "fail" coloring reads better.
+- [ ] Wider-than-default terminal (120+ columns) so `hai stats` doesn't
+      wrap.
+- [ ] Valid Garmin credentials in a password manager, ready to paste.
+- [ ] Test `pipx` is installed (`brew install pipx` or distro equivalent)
+      BEFORE starting the recording — we're demoing `hai`, not `pipx`.
+- [ ] Have `~/.claude/skills/` empty (or renamed aside) so the skills
+      copy step shows real output, not "already present."
+- [ ] Shell history cleared; prompt short (`PS1='$ '`) so commands stand
+      out.
+- [ ] Monitor off sleep / notifications silenced / Do Not Disturb on.
+- [ ] Recording tool: **asciinema** for the CLI-native feel (pastes as
+      text, searchable, lightweight) OR OBS → YouTube if audio narration
+      is wanted. Recommend asciinema for v1; add voiceover later only
+      if it tests better.
+
+## Shot list
+
+The times below are **screen time** (elapsed in the recording). Typing
+speed assumed normal; don't rush — legibility > brevity.
+
+### Shot 1 · 0:00–0:15 · title card / install
+
+```
+$ pipx install health-agent-infra
+```
+
+Let pipx output scroll naturally. If it takes >10s, cut to the last
+line ("installed package ...") in post.
+
+**Voiceover (optional):** *"Health Agent Infra is a governed local
+agent runtime for personal health data. One install, one CLI."*
+
+### Shot 2 · 0:15–0:45 · one-command setup
+
+```
+$ hai init --with-auth --with-first-pull
+```
+
+The wizard should:
+1. Scaffold config + state DB + skills (fast, 1–2s).
+2. Prompt: `Garmin email:` — type the email.
+3. Prompt: `Garmin password:` — paste (password stays hidden).
+4. Pull + project the last 7 days (5–15s depending on Garmin latency).
+5. Emit the consolidated JSON report.
+
+If step 4 takes >15s, **cut** in post to the last 2s of the progress
+output. Don't let the viewer watch the network.
+
+**Voiceover:** *"One command scaffolds the state DB, copies skills into
+Claude Code, authenticates Garmin, and backfills a week of history.
+Idempotent, safe to re-run."*
+
+### Shot 3 · 0:45–0:55 · look at what landed
+
+```
+$ hai doctor
+```
+
+Show the green `ok` rows. Natural segue to "the state exists, it's
+fresh, everything is ready for tomorrow."
+
+**Voiceover:** *"`hai doctor` confirms config, DB, skills, credentials,
+and per-source freshness. Green."*
+
+### Shot 4 · 0:55–2:00 · the morning loop
+
+```
+$ hai daily
+```
+
+This is the centerpiece. Let the JSON report emit in full the first
+time. Two sub-shots:
+
+**4a (0:55–1:25)** — First run, no proposals yet. The output ends with
+`"overall_status": "awaiting_proposals"`. Point out the skill invocation
+seam: the runtime is asking Claude Code to post proposals.
+
+**Voiceover:** *"The runtime pulled today, projected state, snapshotted
+the cross-domain bundle, and paused at the agent seam. Skills are
+judgment-only; code never writes prose."*
+
+**4b (1:25–1:45)** — Switch to Claude Code. Show the agent invoking
+domain skills, posting proposals via `hai propose`. *(If live agent use
+makes the recording flaky, pre-run this step and cut to the "after"
+state.)*
+
+**4c (1:45–2:00)** — Re-run `hai daily`. Synthesis completes; plan and
+recommendations get an atomic commit.
+
+**Voiceover:** *"The agent emits per-domain proposals. Synthesis reconciles
+them through codified cross-domain rules, and the runtime commits an
+atomic plan."*
+
+### Shot 5 · 2:00–2:20 · `hai explain`
+
+```
+$ hai explain --for-date $(date -u +%F)
+```
+
+Show the audit-chain view: which proposals were made, which X-rules
+fired, what changed, what the final recommendation was. This is the
+"governed, not generative" proof.
+
+**Voiceover:** *"Every rule firing is logged. `hai explain` reconstructs
+the full chain from proposals through synthesis mutations to the final
+recommendation."*
+
+### Shot 6 · 2:20–2:40 · `hai stats`
+
+```
+$ hai stats
+```
+
+Sync freshness + recent runs + daily streak. Brief; proves ongoing
+usage is observable locally.
+
+**Voiceover:** *"No telemetry leaves the device. `hai stats` reads
+local tables so you can see your own funnel without anyone else
+reading it."*
+
+### Shot 7 · 2:40–3:00 · closing frame
+
+Static text overlay — no typing. Options:
+
+- Repo URL (GitHub)
+- Short license blurb ("MIT · local-only · no telemetry")
+- "For Claude Code users on macOS / Linux"
+
+End on the repo URL for ~3 seconds, then fade.
+
+## Post-production
+
+- **Trim ruthlessly.** Any frame where the viewer is watching the
+  network/install is dead weight — cut.
+- **Highlight the important lines** with a subtle flash or box
+  annotation (asciinema → try [svg-term-cli](https://github.com/marionebl/svg-term-cli)
+  for a cleaner render that plays anywhere).
+- **Captions on by default.** Muted playback is the norm — the voiceover
+  script above doubles as caption copy. If YouTube, upload `.srt`
+  alongside.
+- **Music: no.** Ambient music distracts from the command output and
+  signals "promotional video." Keep it silent or voice-only.
+- **Length floor: 2:45 · ceiling: 3:15.** If under 2:45 you skipped
+  something; if over 3:15 you're losing the skimmer.
+
+## Publishing
+
+- **asciinema** (primary) — upload to asciinema.org, embed via `<script>`
+  in the README. Pastes cleanly as text; works on HN / Reddit.
+- **YouTube** (secondary) — only if a narrated version is recorded.
+  Link alongside the asciinema from the README; don't substitute one
+  for the other.
+- **Don't auto-embed in the README** until the take is settled. A bad
+  screencast is worse than no screencast. Hand-review once before
+  merging.
+
+## Framing decisions Dom owns
+
+- **Voiceover or silent?** Voiceover doubles reach on social platforms
+  but requires a retake if his voice sounds rushed. Silent is easier
+  to iterate.
+- **Live agent or pre-staged?** Live shows authenticity; pre-staged
+  shows the happy path reliably. My recommendation: pre-stage the
+  agent interaction so the demo doesn't depend on Anthropic API
+  latency, but show the `hai propose` commits landing in real time.
+- **Include `hai review record`?** Closes the loop on "did the plan
+  work?" but adds 30s. Skip for v1 — add in a sequel video if the
+  first one lands.

--- a/reporting/docs/launch/show_hn_draft.md
+++ b/reporting/docs/launch/show_hn_draft.md
@@ -1,0 +1,218 @@
+# Show HN launch post — three drafts + recommendation
+
+The three framings from the v2 plan, each drafted as a complete Show HN
+post. My recommendation is at the bottom.
+
+A Show HN post has two parts that matter:
+1. **Title** (≤80 chars, ≤8 words where possible). The single biggest
+   conversion lever.
+2. **First comment** (the "tell HN" that expands the title). Typically
+   300–500 words. Longer is fine if it earns the attention.
+
+Everything below is a draft in Dom's voice as best I can approximate
+it. **Dom owns the final version** — even if a framing is picked
+unchanged, read every sentence and replace any that doesn't sound like
+something you'd say out loud.
+
+---
+
+## Framing A — Personal testimonial (recommended for Show HN)
+
+### Title
+`Show HN: A local governed agent runtime for my Garmin data (Claude Code + SQLite)`
+
+*Alt title (shorter):* `Show HN: Governed agent runtime over my own health data`
+
+### First comment
+
+I got tired of health apps that give me opaque recommendations I can't
+audit and that phone home with data I'd rather keep local. So I built
+the thing I wanted: a single-user runtime that reads my Garmin data,
+runs a Claude Code agent over it, and commits recommendations to a
+local SQLite file on my own machine. Nothing leaves the device.
+
+The interesting idea for me was the **skill/code split**. Python owns
+every mechanical decision — classification bands, policy rules,
+atomicity, schema validation. Markdown skills (the Claude Code kind)
+own *only* judgment: picking from an already-constrained action set,
+composing rationale, surfacing uncertainty. Skills never change an
+action; code never writes prose. That split is what makes the agent
+recommendations auditable instead of hand-wavy — every rule firing
+lands in a typed table you can SELECT against.
+
+Six domains in v1: recovery, running, sleep, stress, strength, and
+(macros-only) nutrition. Each has its own state projection, rule
+set, and readiness skill; a synthesis pass reconciles them via
+codified cross-domain rules (e.g., "if yesterday was a hard session
+and HRV is suppressed, downgrade today's planned run"). `hai daily`
+runs the full loop in one command. `hai explain` reconstructs the
+audit chain — proposals → rule firings → final recommendation.
+
+It's not an MLOps project, not a wearable API, not clinical. It's
+infrastructure a Claude Code agent consumes. It exists because I
+wanted something I could actually trust, and every design tenet —
+local, deterministic tools, governed skills — is what I'd want
+protected as it scales.
+
+Install: `pipx install health-agent-infra && hai init --with-auth
+--with-first-pull`, then `hai daily` tomorrow morning. Requires a
+Garmin device and Claude Code today; MCP portability and additional
+wearables (Apple Health, Oura, Whoop) are on the roadmap.
+
+Source: [GITHUB_URL]
+
+Happy to answer questions about the architecture, the skill/code
+boundary, or why I think local-first agents need to look like this.
+
+---
+
+## Framing B — Technical architecture
+
+### Title
+`Show HN: Governed agent runtime — Claude Code + SQLite + six domain skills`
+
+### First comment
+
+Most "AI health" projects lean hard on model capability and very
+little on constraints. Health Agent Infra is the opposite: the model
+(a Claude Code agent) operates inside a deterministic frame of Python
+tools, with judgment limited to composing rationale over an
+already-bounded action set.
+
+Architecture in one paragraph: a local SQLite DB holds cross-domain
+state projections for six health domains (recovery, running, sleep,
+stress, strength, nutrition). A morning orchestrator — `hai daily` —
+pulls fresh data, cleans it, projects accepted state, snapshots the
+cross-domain bundle, and emits it to a Claude Code agent. The agent
+invokes per-domain skills that emit typed `DomainProposal` objects.
+A synthesis pass runs codified cross-domain rules (X-rules) over the
+proposals, mutating drafts atomically. Every firing lands in
+`x_rule_firing`; the final plan commits transactionally with its
+recommendations and scheduled reviews. `hai explain` reconstructs
+the chain for any day.
+
+The invariants that matter:
+- Python code never writes prose. Markdown skills never change an
+  action. The boundary is enforced by `agent-safe` CLI annotations.
+- All mutations are atomic. A partial failure rolls back; there's no
+  "half-applied plan" state.
+- Every read surface (`hai snapshot`, `hai explain`, `hai stats`,
+  `hai doctor`) is strictly read-only.
+- No remote calls except to Garmin's API with the user's own
+  credentials (keyring). No telemetry.
+
+It's MIT-licensed, runs on macOS and Linux, requires Python 3.11+
+and Claude Code. 1200+ tests, 28 eval scenarios, atomic audit chain
+end-to-end.
+
+Install: `pipx install health-agent-infra && hai init --with-auth
+--with-first-pull`.
+
+Source: [GITHUB_URL]
+
+Feedback especially welcome on the skill/code boundary — whether
+that split is the right level of constraint, or whether it's too
+rigid for the judgment-heavy parts.
+
+---
+
+## Framing C — Reference implementation (recommended for Claude Code audiences)
+
+### Title
+`Show HN: Reference implementation of Anthropic's skills pattern (multi-domain health)`
+
+### First comment
+
+Anthropic's skills pattern — markdown instructions that a Claude Code
+agent invokes alongside deterministic tools — is elegant in the
+abstract but scarce in the wild as a non-trivial end-to-end example.
+Health Agent Infra is one: six domain skills, a synthesis skill, a
+writeback-protocol skill, and an intake-routing skill, all composed
+over a deterministic Python runtime with atomic commits and a real
+audit chain.
+
+The pattern I found worked:
+- Python tools own every mechanical decision (classification bands,
+  policy rules, atomicity, schema validation).
+- Markdown skills own only judgment (picking from a constrained
+  action set, composing rationale, surfacing uncertainty).
+- The boundary is tight and enforced. Skills never change an action;
+  code never writes prose. Every CLI command is annotated agent-safe
+  or interactive; the agent only calls the agent-safe surface.
+
+I applied this to personal health data because it's a domain with
+enough mechanical structure to formalize (HRV bands, training load,
+sleep stages, X-rules across domains) and enough judgment to make the
+skill layer pull its weight (which proposal to surface, what
+uncertainty to flag, how much rationale to write). Six v1 domains,
+ten cross-domain X-rules, 28 eval scenarios, full audit chain.
+
+The artifact I'd most value feedback on: `reporting/docs/architecture.md`
+and `reporting/docs/agent_cli_contract.md`. The first documents the
+boundary. The second is an auto-generated manifest of every CLI
+surface the agent can call, including mutation class and idempotency.
+Both are where the skills pattern earns its keep or doesn't.
+
+MIT-licensed. Claude Code + Garmin today; MCP-portable and
+multi-source on the roadmap.
+
+Install: `pipx install health-agent-infra && hai init --with-auth
+--with-first-pull`.
+
+Source: [GITHUB_URL]
+
+---
+
+## Recommendation
+
+**Pick Framing A for the HN launch.**
+
+Reasoning:
+- HN front-page conversion skews heavily on the *human story* in the
+  first two sentences. "I got tired of X so I built Y" is an evergreen
+  HN structure that beats "here is a reference implementation of Z"
+  on raw upvote rate.
+- The governance pitch (Framing B) is correct but generic — many
+  projects claim auditability. Doesn't differentiate in a skim.
+- The reference-implementation framing (Framing C) is better for a
+  narrower audience (Claude Code forums, r/Anthropic) because it
+  flags "interesting to people thinking about agent architecture."
+  On HN generally it undersells — positions the project as an
+  example of someone else's idea.
+
+**If the primary channel changes to Claude Code communities** (Discord,
+internal forums, r/Anthropic): switch to Framing C. It lands harder
+with the skills-pattern-curious audience and doesn't have to compete
+for HN's attention budget.
+
+**If posting to r/QuantifiedSelf or r/selfhosted**: use Framing A's
+body but change the title to lead with the wearable + local-first
+angle rather than the AI angle. QS readers have high tolerance for
+technical depth but will bounce off "AI" framing that feels
+promotional.
+
+## What Dom owns
+
+- **The opening two sentences of Framing A.** They need to sound
+  exactly like you'd write them, not like me approximating you. If
+  any of my phrasing is even slightly off, rewrite it — the
+  first-person hook only works when the voice is real.
+- **The "Happy to answer questions about..." closing.** Pick the
+  topics you actually want to discuss. That shapes who engages.
+- **The timing.** HN is best Tue–Thu, 8–10am PT. Don't post right
+  before a long meeting — the first hour is when engagement is
+  load-bearing and you want to be responsive.
+- **`[GITHUB_URL]`** — replace with the public repo URL before
+  posting. Verify the install command works end-to-end on a fresh
+  machine right before submission.
+
+## What I'd NOT do
+
+- Cross-post simultaneously to HN and Reddit. One shot per venue;
+  preserve the novelty for each.
+- Ask friends to upvote. HN detects rings; a well-written post earns
+  its placement or it doesn't.
+- Respond defensively to criticism. If someone says "this is just X,"
+  acknowledge the overlap and state what's different in one sentence.
+  The people reading the thread are your real audience; the
+  commenter has already decided.

--- a/safety/tests/test_cli_init_doctor.py
+++ b/safety/tests/test_cli_init_doctor.py
@@ -381,3 +381,297 @@ def test_doctor_partial_skills_install_is_warn(
     assert skills["packaged_count"] >= 2
     # The other packaged skills show up in missing.
     assert "daily-plan-synthesis" in skills["missing"]
+
+
+# ---------------------------------------------------------------------------
+# hai init --with-auth
+# ---------------------------------------------------------------------------
+
+
+class _NoRawRowAdapter:
+    """Fake live adapter: reports as garmin_live, returns no raw_daily_row.
+
+    No raw_daily_row means _daily_pull_and_project returns projected=False
+    and skips projection — the pull path and sync_run_log bookkeeping are
+    exercised without needing the full projection-friendly row shape. The
+    projection path has its own tests; the backfill loop is the target
+    here.
+    """
+
+    source_name = "garmin_live"
+
+    def load(self, as_of):
+        return {
+            "sleep": None,
+            "resting_hr": [],
+            "hrv": [],
+            "training_load": [],
+            "raw_daily_row": None,
+        }
+
+
+def test_init_with_auth_noops_when_already_configured(
+    tmp_path, capsys, fake_stored_store,
+):
+    rc = cli_main(_init_argv(tmp_path, "--with-auth"))
+    assert rc == 0
+    report = _stdout_json(capsys)
+
+    # Existing steps still present and unchanged in shape.
+    assert report["steps"]["auth_garmin"]["credentials_available"] is True
+    # New step records the short-circuit.
+    assert report["steps"]["interactive_auth"]["status"] == "already_configured"
+
+
+def test_init_with_auth_prompts_and_stores(
+    tmp_path, capsys, monkeypatch, fake_empty_store,
+):
+    # Simulate a user typing an email at input() and a password at getpass().
+    import builtins
+    import getpass as getpass_mod
+
+    prompts_seen: list[str] = []
+
+    def fake_input(prompt: str = "") -> str:
+        prompts_seen.append(prompt)
+        return "new_user@example.com"
+
+    def fake_getpass(prompt: str = "") -> str:
+        prompts_seen.append(prompt)
+        return "s3cret!"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+    monkeypatch.setattr(getpass_mod, "getpass", fake_getpass)
+
+    rc = cli_main(_init_argv(tmp_path, "--with-auth"))
+    assert rc == 0
+    report = _stdout_json(capsys)
+
+    assert report["steps"]["interactive_auth"]["status"] == "configured"
+    # Credentials actually landed in the injected keyring.
+    creds = fake_empty_store.load_garmin()
+    assert creds is not None
+    assert creds.email == "new_user@example.com"
+    assert creds.password == "s3cret!"
+    # Both prompts fired — proof we actually hit the interactive path.
+    assert any("email" in p.lower() for p in prompts_seen)
+    assert any("password" in p.lower() for p in prompts_seen)
+
+
+def test_init_with_auth_emits_single_json_document(
+    tmp_path, capsys, monkeypatch, fake_empty_store,
+):
+    """cmd_auth_garmin's own JSON is silenced so stdout stays a single doc."""
+
+    import builtins
+    import getpass as getpass_mod
+
+    monkeypatch.setattr(builtins, "input", lambda _="": "a@b.com")
+    monkeypatch.setattr(getpass_mod, "getpass", lambda _="": "pw")
+
+    rc = cli_main(_init_argv(tmp_path, "--with-auth"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Exactly one JSON document on stdout — json.loads on the whole stream
+    # would fail if cmd_auth_garmin had leaked its own JSON through.
+    parsed = json.loads(out)
+    assert "steps" in parsed
+
+
+def test_init_with_auth_handles_eof_gracefully(
+    tmp_path, capsys, monkeypatch, fake_empty_store,
+):
+    # No stdin → cmd_auth_garmin's input() raises EOFError; we report
+    # user_skipped rather than surfacing the traceback.
+    import builtins
+
+    def raising_input(prompt: str = "") -> str:
+        raise EOFError()
+
+    monkeypatch.setattr(builtins, "input", raising_input)
+
+    rc = cli_main(_init_argv(tmp_path, "--with-auth"))
+    assert rc == 0
+    report = _stdout_json(capsys)
+    assert report["steps"]["interactive_auth"]["status"] == "user_skipped"
+
+
+# ---------------------------------------------------------------------------
+# hai init --with-first-pull
+# ---------------------------------------------------------------------------
+
+
+def test_init_with_first_pull_skips_without_credentials(
+    tmp_path, capsys, fake_empty_store,
+):
+    rc = cli_main(_init_argv(tmp_path, "--with-first-pull"))
+    assert rc == 0
+    report = _stdout_json(capsys)
+    first = report["steps"]["first_pull"]
+    assert first["status"] == "skipped"
+    assert "credentials" in first["reason"].lower()
+
+
+def test_init_with_first_pull_runs_default_seven_days(
+    tmp_path, capsys, monkeypatch, fake_stored_store,
+):
+    # Inject a fake live adapter so no network / real Garmin call happens.
+    monkeypatch.setattr(
+        cli_mod, "_build_live_adapter", lambda args: _NoRawRowAdapter(),
+    )
+
+    rc = cli_main(_init_argv(tmp_path, "--with-first-pull"))
+    assert rc == 0
+    report = _stdout_json(capsys)
+
+    first = report["steps"]["first_pull"]
+    assert first["status"] == "ran"
+    assert first["days_requested"] == 7
+    assert first["days_succeeded"] == 7
+    assert first["days_failed"] == 0
+    assert len(first["per_day"]) == 7
+    # Dates are unique and chronological (oldest → newest).
+    dates_seen = [entry["date"] for entry in first["per_day"]]
+    assert dates_seen == sorted(dates_seen)
+    assert len(set(dates_seen)) == 7
+    # Every entry reports the source name and no projection (no raw_daily_row).
+    for entry in first["per_day"]:
+        assert entry["status"] == "ok"
+        assert entry["source"] == "garmin_live"
+        assert entry["projected_raw_daily"] is False
+
+
+def test_init_with_first_pull_respects_days_override(
+    tmp_path, capsys, monkeypatch, fake_stored_store,
+):
+    monkeypatch.setattr(
+        cli_mod, "_build_live_adapter", lambda args: _NoRawRowAdapter(),
+    )
+
+    rc = cli_main(_init_argv(tmp_path, "--with-first-pull", "--first-pull-days", "3"))
+    assert rc == 0
+    report = _stdout_json(capsys)
+
+    first = report["steps"]["first_pull"]
+    assert first["days_requested"] == 3
+    assert first["days_succeeded"] == 3
+    assert len(first["per_day"]) == 3
+
+
+def test_init_with_first_pull_writes_one_sync_row_per_day(
+    tmp_path, capsys, monkeypatch, fake_stored_store,
+):
+    from health_agent_infra.core.state import open_connection
+
+    monkeypatch.setattr(
+        cli_mod, "_build_live_adapter", lambda args: _NoRawRowAdapter(),
+    )
+
+    rc = cli_main(_init_argv(tmp_path, "--with-first-pull", "--first-pull-days", "4"))
+    assert rc == 0
+
+    conn = open_connection(tmp_path / "state.db")
+    try:
+        rows = conn.execute(
+            "SELECT source, status, mode, for_date FROM sync_run_log "
+            "ORDER BY sync_id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    # Four successful live-pull rows, one per backfill day.
+    assert len(rows) == 4
+    assert all(row["source"] == "garmin_live" for row in rows)
+    assert all(row["status"] == "ok" for row in rows)
+    assert all(row["mode"] == "live" for row in rows)
+    # for_date values cover a chronological 4-day window with no gaps.
+    for_dates = sorted(row["for_date"] for row in rows)
+    assert len(set(for_dates)) == 4
+
+
+def test_init_with_first_pull_continues_past_per_day_failure(
+    tmp_path, capsys, monkeypatch, fake_stored_store,
+):
+    from health_agent_infra.core.pull.garmin_live import GarminLiveError
+
+    class _SometimesFailingAdapter:
+        source_name = "garmin_live"
+
+        def __init__(self):
+            self._call_count = 0
+
+        def load(self, as_of):
+            self._call_count += 1
+            # Fail on the 2nd call so we can prove the loop doesn't abort.
+            if self._call_count == 2:
+                raise GarminLiveError("simulated 503 on day 2")
+            return {
+                "sleep": None,
+                "resting_hr": [],
+                "hrv": [],
+                "training_load": [],
+                "raw_daily_row": None,
+            }
+
+    # Reuse one adapter instance across the backfill so call_count survives.
+    adapter = _SometimesFailingAdapter()
+    monkeypatch.setattr(cli_mod, "_build_live_adapter", lambda args: adapter)
+
+    rc = cli_main(_init_argv(tmp_path, "--with-first-pull", "--first-pull-days", "5"))
+    assert rc == 0
+    report = _stdout_json(capsys)
+
+    first = report["steps"]["first_pull"]
+    assert first["status"] == "ran"
+    assert first["days_requested"] == 5
+    assert first["days_succeeded"] == 4
+    assert first["days_failed"] == 1
+    # The failure entry carries error context for later triage.
+    failed_entries = [e for e in first["per_day"] if e["status"] == "failed"]
+    assert len(failed_entries) == 1
+    assert failed_entries[0]["error_class"] == "GarminLiveError"
+    assert "503" in failed_entries[0]["error"]
+
+
+def test_init_with_auth_and_first_pull_end_to_end(
+    tmp_path, capsys, monkeypatch, fake_empty_store,
+):
+    """Happy path: fresh machine → --with-auth → --with-first-pull in one call."""
+
+    import builtins
+    import getpass as getpass_mod
+
+    monkeypatch.setattr(builtins, "input", lambda _="": "flow@example.com")
+    monkeypatch.setattr(getpass_mod, "getpass", lambda _="": "s3cret")
+    monkeypatch.setattr(
+        cli_mod, "_build_live_adapter", lambda args: _NoRawRowAdapter(),
+    )
+
+    rc = cli_main(_init_argv(
+        tmp_path, "--with-auth", "--with-first-pull", "--first-pull-days", "2",
+    ))
+    assert rc == 0
+    report = _stdout_json(capsys)
+
+    # Step 5: auth moved from missing → configured.
+    assert report["steps"]["auth_garmin"]["status"] == "missing"  # pre-prompt snapshot
+    assert report["steps"]["interactive_auth"]["status"] == "configured"
+
+    # Step 6: first-pull honoured the freshly-stored creds.
+    first = report["steps"]["first_pull"]
+    assert first["status"] == "ran"
+    assert first["days_requested"] == 2
+    assert first["days_succeeded"] == 2
+
+
+def test_init_without_new_flags_does_not_add_new_steps(
+    tmp_path, capsys, fake_empty_store,
+):
+    """Backward compatibility: default `hai init` shape is unchanged."""
+
+    rc = cli_main(_init_argv(tmp_path))
+    assert rc == 0
+    report = _stdout_json(capsys)
+
+    expected_steps = {"config", "state_db", "skills", "auth_garmin"}
+    assert set(report["steps"].keys()) == expected_steps

--- a/safety/tests/test_cli_stats.py
+++ b/safety/tests/test_cli_stats.py
@@ -1,0 +1,301 @@
+"""Tests for ``hai stats`` + the ``cmd_daily`` instrumentation hook.
+
+``hai stats`` is a read-only local summary of sync_run_log (freshness
+per source) and runtime_event_log (recent commands, daily streak). The
+command never leaves the device; it reads the DB the user already owns.
+
+The ``cmd_daily`` tests here check the *wrapping* behavior: every
+invocation writes one runtime_event_log row regardless of outcome
+(awaiting_proposals, complete, failed), so downstream streak + freshness
+math is sound.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from health_agent_infra.cli import main as cli_main
+from health_agent_infra.core import exit_codes
+from health_agent_infra.core.state import (
+    begin_sync,
+    complete_sync,
+    initialize_database,
+    open_connection,
+)
+
+
+def _fresh_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "state.db"
+    initialize_database(db_path)
+    return db_path
+
+
+def _stats_argv(db_path: Path, *extra: str) -> list[str]:
+    return ["stats", "--db-path", str(db_path), *extra]
+
+
+# ---------------------------------------------------------------------------
+# hai stats — fresh DB / missing DB
+# ---------------------------------------------------------------------------
+
+
+def test_stats_requires_existing_db(tmp_path, capsys):
+    missing = tmp_path / "absent.db"
+    rc = cli_main(["stats", "--db-path", str(missing)])
+    assert rc == exit_codes.USER_INPUT
+    err = capsys.readouterr().err
+    assert "hai init" in err
+
+
+def test_stats_json_missing_db_reports_status(tmp_path, capsys):
+    missing = tmp_path / "absent.db"
+    rc = cli_main(["stats", "--db-path", str(missing), "--json"])
+    assert rc == exit_codes.USER_INPUT
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "db_missing"
+    assert "hai init" in payload["hint"]
+
+
+def test_stats_fresh_db_renders_empty_sections(tmp_path, capsys):
+    db_path = _fresh_db(tmp_path)
+    rc = cli_main(_stats_argv(db_path))
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Text view names each section even when it's empty.
+    assert "Sync freshness" in out
+    assert "Recent runs" in out
+    assert "Command summary" in out
+    assert "Daily streak: 0" in out
+
+
+def test_stats_fresh_db_json_shape(tmp_path, capsys):
+    db_path = _fresh_db(tmp_path)
+    rc = cli_main(_stats_argv(db_path, "--json"))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert set(payload.keys()) >= {
+        "db_path", "user_id", "sync_freshness",
+        "recent_events", "command_summary", "daily_streak_days",
+    }
+    assert payload["sync_freshness"] == {}
+    assert payload["recent_events"] == []
+    assert payload["command_summary"] == {}
+    assert payload["daily_streak_days"] == 0
+
+
+# ---------------------------------------------------------------------------
+# hai stats — with real sync + event data
+# ---------------------------------------------------------------------------
+
+
+def test_stats_reports_sync_freshness_per_source(tmp_path, capsys):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        # Two successful syncs against the same source: the most recent wins.
+        s1 = begin_sync(conn, source="garmin_live", user_id="u_local_1",
+                        mode="live", for_date=date(2026, 4, 20))
+        complete_sync(conn, s1, rows_pulled=1, rows_accepted=1,
+                      duplicates_skipped=0, status="ok")
+        s2 = begin_sync(conn, source="garmin_live", user_id="u_local_1",
+                        mode="live", for_date=date(2026, 4, 21))
+        complete_sync(conn, s2, rows_pulled=1, rows_accepted=1,
+                      duplicates_skipped=0, status="ok")
+        # Different source.
+        s3 = begin_sync(conn, source="garmin", user_id="u_local_1",
+                        mode="csv", for_date=date(2026, 4, 21))
+        complete_sync(conn, s3, rows_pulled=1, rows_accepted=1,
+                      duplicates_skipped=0, status="ok")
+    finally:
+        conn.close()
+
+    rc = cli_main(_stats_argv(db_path, "--json"))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    fresh = payload["sync_freshness"]
+    assert set(fresh.keys()) == {"garmin_live", "garmin"}
+    assert fresh["garmin_live"]["for_date"] == "2026-04-21"
+    assert fresh["garmin_live"]["mode"] == "live"
+    assert fresh["garmin"]["mode"] == "csv"
+
+
+def test_stats_reports_recent_events_after_daily_runs(tmp_path, capsys, monkeypatch):
+    """A successful `hai daily` run writes a runtime_event_log row."""
+
+    db_path = _fresh_db(tmp_path)
+
+    # Run hai daily with --skip-pull --skip-reviews so no Garmin dep is needed.
+    # There are no proposals, so the run exits with awaiting_proposals (rc=0),
+    # still a successful invocation for our purposes.
+    rc = cli_main([
+        "daily",
+        "--db-path", str(db_path),
+        "--base-dir", str(tmp_path / "runtime"),
+        "--skip-pull",
+        "--skip-reviews",
+    ])
+    assert rc == 0
+    capsys.readouterr()  # discard daily output
+
+    rc = cli_main(_stats_argv(db_path, "--json"))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    events = payload["recent_events"]
+    assert len(events) == 1
+    assert events[0]["command"] == "daily"
+    assert events[0]["status"] == "ok"
+    assert events[0]["exit_code"] == 0
+    assert events[0]["duration_ms"] is not None
+    # Command summary agrees.
+    assert payload["command_summary"]["daily"]["ok"] == 1
+
+
+def test_stats_limit_caps_recent_events(tmp_path, capsys):
+    """--limit N trims the recent_events window."""
+
+    db_path = _fresh_db(tmp_path)
+
+    # Run hai daily five times.
+    for _ in range(5):
+        cli_main(["daily", "--db-path", str(db_path),
+                  "--base-dir", str(tmp_path / "runtime"),
+                  "--skip-pull", "--skip-reviews"])
+        capsys.readouterr()
+
+    rc = cli_main(_stats_argv(db_path, "--json", "--limit", "3"))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["recent_events"]) == 3
+    assert payload["command_summary"]["daily"]["total"] == 5
+
+
+def test_stats_daily_streak_counts_consecutive_ok_days(tmp_path, capsys):
+    """Streak is consecutive UTC calendar days with >=1 successful daily run."""
+
+    db_path = _fresh_db(tmp_path)
+
+    # Insert three runtime_event_log rows by hand, one per day for the
+    # last 3 days (including today). Going via cli_main would collapse
+    # them onto today's date.
+    today = datetime.now(timezone.utc).date()
+    conn = open_connection(db_path)
+    try:
+        for offset in (2, 1, 0):
+            day = today - timedelta(days=offset)
+            started = datetime.combine(day, datetime.min.time(),
+                                       tzinfo=timezone.utc)
+            conn.execute(
+                "INSERT INTO runtime_event_log "
+                "(command, user_id, started_at, completed_at, status, exit_code) "
+                "VALUES ('daily', 'u_local_1', ?, ?, 'ok', 0)",
+                (started.isoformat(), started.isoformat()),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    rc = cli_main(_stats_argv(db_path, "--json"))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["daily_streak_days"] == 3
+
+
+def test_stats_daily_streak_breaks_on_gap(tmp_path, capsys):
+    db_path = _fresh_db(tmp_path)
+
+    today = datetime.now(timezone.utc).date()
+    conn = open_connection(db_path)
+    try:
+        # today + day-2 (gap on day-1) → streak is 1, not 3.
+        for offset in (2, 0):
+            day = today - timedelta(days=offset)
+            started = datetime.combine(day, datetime.min.time(),
+                                       tzinfo=timezone.utc)
+            conn.execute(
+                "INSERT INTO runtime_event_log "
+                "(command, user_id, started_at, completed_at, status, exit_code) "
+                "VALUES ('daily', 'u_local_1', ?, ?, 'ok', 0)",
+                (started.isoformat(), started.isoformat()),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    rc = cli_main(_stats_argv(db_path, "--json"))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["daily_streak_days"] == 1
+
+
+def test_stats_daily_streak_zero_when_today_missing(tmp_path, capsys):
+    db_path = _fresh_db(tmp_path)
+
+    today = datetime.now(timezone.utc).date()
+    conn = open_connection(db_path)
+    try:
+        # Ran yesterday and day-before, but not today. Streak is 0.
+        for offset in (2, 1):
+            day = today - timedelta(days=offset)
+            started = datetime.combine(day, datetime.min.time(),
+                                       tzinfo=timezone.utc)
+            conn.execute(
+                "INSERT INTO runtime_event_log "
+                "(command, user_id, started_at, completed_at, status, exit_code) "
+                "VALUES ('daily', 'u_local_1', ?, ?, 'ok', 0)",
+                (started.isoformat(), started.isoformat()),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    rc = cli_main(_stats_argv(db_path, "--json"))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["daily_streak_days"] == 0
+
+
+# ---------------------------------------------------------------------------
+# cmd_daily instrumentation — wrapper must write one row per invocation
+# ---------------------------------------------------------------------------
+
+
+def test_daily_wrapper_records_awaiting_proposals_as_ok(tmp_path, capsys):
+    db_path = _fresh_db(tmp_path)
+
+    rc = cli_main(["daily", "--db-path", str(db_path),
+                   "--base-dir", str(tmp_path / "runtime"),
+                   "--skip-pull", "--skip-reviews"])
+    assert rc == 0
+    capsys.readouterr()
+
+    conn = open_connection(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM runtime_event_log ORDER BY event_id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 1
+    assert rows[0]["command"] == "daily"
+    assert rows[0]["status"] == "ok"
+    assert rows[0]["exit_code"] == 0
+
+
+def test_daily_wrapper_records_failure_when_db_missing(tmp_path, capsys):
+    """Pre-init: `hai daily` bails with USER_INPUT. The wrapper no-ops
+    silently because the DB doesn't exist — no row to write."""
+
+    missing = tmp_path / "never.db"
+    rc = cli_main(["daily", "--db-path", str(missing),
+                   "--base-dir", str(tmp_path / "runtime")])
+    assert rc == exit_codes.USER_INPUT
+    # Silently skipped logging — no DB was created as a side-effect.
+    assert not missing.exists()

--- a/safety/tests/test_runtime_event_log.py
+++ b/safety/tests/test_runtime_event_log.py
@@ -1,0 +1,307 @@
+"""Tests for ``runtime_event_log`` (migration 012) + primitives + context manager.
+
+Exercises the row lifecycle directly against a fresh DB, plus the
+graceful-degradation paths (DB missing, pre-migration schema) so callers
+that adopt the context manager don't have to add defensive checks of
+their own.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from health_agent_infra.core.state import (
+    begin_event,
+    command_summary,
+    complete_event,
+    fail_event,
+    initialize_database,
+    open_connection,
+    recent_events,
+    runtime_event,
+)
+
+
+def _fresh_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "state.db"
+    initialize_database(db_path)
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Primitives
+# ---------------------------------------------------------------------------
+
+
+def test_begin_event_inserts_pessimistic_failed_row(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        event_id = begin_event(conn, command="daily", user_id="u_local_1")
+        assert event_id >= 1
+
+        row = conn.execute(
+            "SELECT * FROM runtime_event_log WHERE event_id = ?", (event_id,),
+        ).fetchone()
+        # Pessimistic default: status='failed', completed_at unset.
+        assert row["command"] == "daily"
+        assert row["user_id"] == "u_local_1"
+        assert row["status"] == "failed"
+        assert row["completed_at"] is None
+        assert row["exit_code"] is None
+    finally:
+        conn.close()
+
+
+def test_complete_event_stamps_ok_status_and_counts(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        event_id = begin_event(conn, command="daily", user_id="u")
+        complete_event(
+            conn, event_id,
+            status="ok", exit_code=0, duration_ms=1234,
+            context={"overall_status": "complete"},
+        )
+        row = conn.execute(
+            "SELECT * FROM runtime_event_log WHERE event_id = ?", (event_id,),
+        ).fetchone()
+        assert row["status"] == "ok"
+        assert row["exit_code"] == 0
+        assert row["duration_ms"] == 1234
+        assert row["completed_at"] is not None
+        assert json.loads(row["context_json"]) == {"overall_status": "complete"}
+    finally:
+        conn.close()
+
+
+def test_complete_event_rejects_invalid_status(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        event_id = begin_event(conn, command="daily")
+        with pytest.raises(ValueError, match="status must be"):
+            complete_event(conn, event_id, status="weird")  # type: ignore[arg-type]
+    finally:
+        conn.close()
+
+
+def test_fail_event_records_exception_metadata(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        event_id = begin_event(conn, command="daily", user_id="u")
+        fail_event(
+            conn, event_id,
+            error_class="RuntimeError",
+            error_message="kaboom",
+            exit_code=1,
+            duration_ms=42,
+        )
+        row = conn.execute(
+            "SELECT * FROM runtime_event_log WHERE event_id = ?", (event_id,),
+        ).fetchone()
+        assert row["status"] == "failed"
+        assert row["error_class"] == "RuntimeError"
+        assert row["error_message"] == "kaboom"
+        assert row["exit_code"] == 1
+        assert row["duration_ms"] == 42
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_event_happy_path_writes_ok_row(tmp_path):
+    db_path = _fresh_db(tmp_path)
+
+    with runtime_event(db_path, command="daily", user_id="u") as evt:
+        evt["exit_code"] = 0
+        evt["context"] = {"overall_status": "complete"}
+
+    conn = open_connection(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM runtime_event_log ORDER BY event_id"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["command"] == "daily"
+    assert row["status"] == "ok"
+    assert row["exit_code"] == 0
+    assert row["duration_ms"] is not None
+    assert json.loads(row["context_json"]) == {"overall_status": "complete"}
+
+
+def test_runtime_event_nonzero_exit_code_marks_failed(tmp_path):
+    db_path = _fresh_db(tmp_path)
+
+    with runtime_event(db_path, command="daily", user_id="u") as evt:
+        evt["exit_code"] = 2  # USER_INPUT
+
+    conn = open_connection(db_path)
+    try:
+        row = conn.execute(
+            "SELECT * FROM runtime_event_log ORDER BY event_id DESC LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["status"] == "failed"
+    assert row["exit_code"] == 2
+    # Non-zero exit != exception, so error_class stays NULL.
+    assert row["error_class"] is None
+
+
+def test_runtime_event_exception_records_and_reraises(tmp_path):
+    db_path = _fresh_db(tmp_path)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with runtime_event(db_path, command="daily", user_id="u"):
+            raise RuntimeError("boom")
+
+    conn = open_connection(db_path)
+    try:
+        row = conn.execute(
+            "SELECT * FROM runtime_event_log ORDER BY event_id DESC LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["status"] == "failed"
+    assert row["error_class"] == "RuntimeError"
+    assert row["error_message"] == "boom"
+
+
+def test_runtime_event_on_missing_db_is_noop(tmp_path):
+    """No DB at path → yield dict but never attempt to insert."""
+
+    missing = tmp_path / "does-not-exist.db"
+    with runtime_event(missing, command="daily", user_id="u") as evt:
+        evt["exit_code"] = 0
+
+    # No file materialised as a side-effect.
+    assert not missing.exists()
+
+
+def test_runtime_event_on_none_db_is_noop(tmp_path):
+    with runtime_event(None, command="daily", user_id="u") as evt:
+        evt["exit_code"] = 0
+    # Nothing to assert beyond "didn't raise."
+
+
+def test_runtime_event_on_pre_migration_db_is_noop(tmp_path):
+    """A DB present but missing migration 012 still runs the body."""
+
+    db_path = tmp_path / "old.db"
+    conn = sqlite3.connect(db_path)
+    # Create a minimal schema_migrations table but DON'T apply migration 012.
+    conn.execute(
+        "CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, filename TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+    with runtime_event(db_path, command="daily", user_id="u") as evt:
+        evt["exit_code"] = 0
+
+    # runtime_event_log was never created; the body ran to completion anyway.
+    conn = sqlite3.connect(db_path)
+    try:
+        tables = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    finally:
+        conn.close()
+    assert "runtime_event_log" not in tables
+
+
+# ---------------------------------------------------------------------------
+# Readers
+# ---------------------------------------------------------------------------
+
+
+def test_recent_events_returns_newest_first(tmp_path):
+    db_path = _fresh_db(tmp_path)
+
+    for i in range(5):
+        with runtime_event(db_path, command="daily", user_id="u") as evt:
+            evt["exit_code"] = 0
+
+    conn = open_connection(db_path)
+    try:
+        events = recent_events(conn, command="daily", limit=3)
+    finally:
+        conn.close()
+
+    assert len(events) == 3
+    # Descending by started_at — the most-recently-inserted event is first.
+    started_ats = [e["started_at"] for e in events]
+    assert started_ats == sorted(started_ats, reverse=True)
+
+
+def test_recent_events_filters_by_command(tmp_path):
+    db_path = _fresh_db(tmp_path)
+
+    with runtime_event(db_path, command="daily") as e:
+        e["exit_code"] = 0
+    with runtime_event(db_path, command="init") as e:
+        e["exit_code"] = 0
+    with runtime_event(db_path, command="daily") as e:
+        e["exit_code"] = 0
+
+    conn = open_connection(db_path)
+    try:
+        only_daily = recent_events(conn, command="daily", limit=10)
+        all_events = recent_events(conn, limit=10)
+    finally:
+        conn.close()
+
+    assert len(only_daily) == 2
+    assert all(e["command"] == "daily" for e in only_daily)
+    assert len(all_events) == 3
+
+
+def test_command_summary_counts_ok_vs_failed(tmp_path):
+    db_path = _fresh_db(tmp_path)
+
+    # Two daily ok, one daily failed (via exception), one init ok.
+    with runtime_event(db_path, command="daily") as e:
+        e["exit_code"] = 0
+    with runtime_event(db_path, command="daily") as e:
+        e["exit_code"] = 0
+    with pytest.raises(RuntimeError):
+        with runtime_event(db_path, command="daily"):
+            raise RuntimeError("x")
+    with runtime_event(db_path, command="init") as e:
+        e["exit_code"] = 0
+
+    conn = open_connection(db_path)
+    try:
+        summary = command_summary(conn)
+    finally:
+        conn.close()
+
+    assert summary["daily"] == {"ok": 2, "failed": 1, "total": 3}
+    assert summary["init"] == {"ok": 1, "failed": 0, "total": 1}
+
+
+def test_recent_events_empty_on_fresh_db(tmp_path):
+    db_path = _fresh_db(tmp_path)
+    conn = open_connection(db_path)
+    try:
+        assert recent_events(conn) == []
+        assert command_summary(conn) == {}
+    finally:
+        conn.close()

--- a/safety/tests/test_state_store.py
+++ b/safety/tests/test_state_store.py
@@ -114,6 +114,7 @@ def test_schema_migrations_has_one_row_per_applied_migration(tmp_path: Path):
         (9, "009_recommendation_log_fk.sql"),
         (10, "010_review_outcome_enrichment.sql"),
         (11, "011_planned_recommendation.sql"),
+        (12, "012_runtime_event_log.sql"),
     ]
 
 
@@ -129,7 +130,7 @@ def test_schema_migrations_not_duplicated_on_repeat_init(tmp_path: Path):
     finally:
         conn.close()
 
-    assert count == 11
+    assert count == 12
 
 
 def test_current_schema_version_zero_on_empty_db(tmp_path: Path):
@@ -147,7 +148,7 @@ def test_current_schema_version_matches_head_after_init(tmp_path: Path):
 
     conn = open_connection(db_path)
     try:
-        assert current_schema_version(conn) == 11
+        assert current_schema_version(conn) == 12
     finally:
         conn.close()
 
@@ -286,8 +287,8 @@ def test_cli_state_migrate_on_head_db_reports_empty_applied(tmp_path: Path, caps
 
     import json
     payload = json.loads(capsys.readouterr().out)
-    assert payload["schema_version_before"] == 11
-    assert payload["schema_version_after"] == 11
+    assert payload["schema_version_before"] == 12
+    assert payload["schema_version_after"] == 12
     assert payload["applied"] == []
 
 
@@ -358,7 +359,7 @@ def test_broken_migration_rolls_back_ddl_and_bookkeeping(tmp_path: Path):
         assert len(rows) == 1
 
         # Version is still at head (pre-broken migration), not 99.
-        assert current_schema_version(conn) == 11
+        assert current_schema_version(conn) == 12
     finally:
         conn.close()
 

--- a/src/health_agent_infra/cli.py
+++ b/src/health_agent_infra/cli.py
@@ -22,7 +22,7 @@ import shutil
 import sqlite3
 import sys
 from dataclasses import asdict, is_dataclass
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -2749,6 +2749,28 @@ def _schedule_reviews_for_daily_plan(
 
 
 def cmd_daily(args: argparse.Namespace) -> int:
+    """Thin wrapper around :func:`_run_daily` that records a runtime event.
+
+    Every invocation writes one row to ``runtime_event_log`` (migration 012)
+    with started_at, exit_code, duration_ms, and status. The wrapper is
+    best-effort: a missing state DB silently skips logging rather than
+    blocking the run. The orchestration logic lives unchanged in
+    :func:`_run_daily`.
+    """
+
+    from health_agent_infra.core.state import resolve_db_path, runtime_event
+
+    db_path_resolved = resolve_db_path(args.db_path)
+    user_id = getattr(args, "user_id", "u_local_1")
+    with runtime_event(
+        db_path_resolved, command="daily", user_id=user_id,
+    ) as evt:
+        rc = _run_daily(args)
+        evt["exit_code"] = rc
+    return rc
+
+
+def _run_daily(args: argparse.Namespace) -> int:
     """Orchestrate the morning sequence over the existing runtime surfaces.
 
     Stages: pull → clean → snapshot → proposal-gate → synthesize →
@@ -3051,7 +3073,8 @@ def cmd_init(args: argparse.Namespace) -> int:
                 }
 
     # 4. Garmin auth — report presence only, never prompt. The operator
-    # runs `hai auth garmin` separately for credential entry.
+    # runs `hai auth garmin` separately for credential entry, or passes
+    # --with-auth (step 5) for one-shot interactive onboarding.
     store = _credential_store_for(args)
     auth_status = store.garmin_status()
     configured = bool(auth_status["credentials_available"])
@@ -3063,14 +3086,167 @@ def cmd_init(args: argparse.Namespace) -> int:
             if configured
             else (
                 "run `hai auth garmin` to store credentials in the OS "
-                "keyring, or set HAI_GARMIN_EMAIL + HAI_GARMIN_PASSWORD "
-                "for non-interactive use"
+                "keyring, or pass --with-auth to prompt interactively, "
+                "or set HAI_GARMIN_EMAIL + HAI_GARMIN_PASSWORD for "
+                "non-interactive use"
             )
         ),
     }
 
+    # 5. optional: interactive Garmin auth. Off by default so agents and
+    # tests can drive `hai init` non-interactively; opt in with --with-auth
+    # for human onboarding.
+    if getattr(args, "with_auth", False):
+        report["steps"]["interactive_auth"] = _run_interactive_auth(
+            args, already_configured=configured,
+        )
+
+    # 6. optional: first-pull backfill via the live adapter. Runs the same
+    # pull + project path `hai daily` uses, N days ending today, one
+    # sync_run_log row per day so freshness + audit stay consistent.
+    if getattr(args, "with_first_pull", False):
+        # Re-check credentials: step 5 may have just populated them.
+        store_now = _credential_store_for(args)
+        creds_now = bool(store_now.garmin_status()["credentials_available"])
+        report["steps"]["first_pull"] = _run_first_pull_backfill(
+            args,
+            db_path=resolved,
+            user_id=getattr(args, "user_id", "u_local_1"),
+            days=int(getattr(args, "first_pull_days", 7) or 7),
+            credentials_available=creds_now,
+        )
+
     _emit_json(report)
     return exit_codes.OK
+
+
+def _run_interactive_auth(
+    args: argparse.Namespace, *, already_configured: bool,
+) -> dict[str, Any]:
+    """Run ``cmd_auth_garmin`` interactively; record outcome only.
+
+    Silences cmd_auth_garmin's own JSON stdout so ``hai init`` emits a
+    single consolidated report. stderr passes through so typos still
+    surface. No-op if credentials are already present.
+    """
+
+    if already_configured:
+        return {"status": "already_configured"}
+
+    import io
+    from contextlib import redirect_stdout
+
+    auth_args = argparse.Namespace(
+        email=None,
+        password_stdin=False,
+        password_env=None,
+        _credential_store_override=getattr(args, "_credential_store_override", None),
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cmd_auth_garmin(auth_args)
+    if rc == exit_codes.OK:
+        return {"status": "configured"}
+    # cmd_auth_garmin maps empty/EOF input to USER_INPUT. In the interactive
+    # `hai init --with-auth` context that's always "user walked away";
+    # other non-OK codes are a real failure worth flagging distinctly.
+    if rc == exit_codes.USER_INPUT:
+        return {"status": "user_skipped", "exit_code": int(rc)}
+    return {"status": "failed", "exit_code": int(rc)}
+
+
+def _run_first_pull_backfill(
+    args: argparse.Namespace,
+    *,
+    db_path: Path,
+    user_id: str,
+    days: int,
+    credentials_available: bool,
+) -> dict[str, Any]:
+    """Pull + project N days via the live adapter, one sync row per day.
+
+    Per-day failures are recorded and the loop continues — a transient
+    Garmin 5xx on day 3 shouldn't wipe out days 4–7 of backfill. Total
+    counts are summarised in the returned dict so the outer init report
+    stays scannable.
+    """
+
+    if not credentials_available:
+        return {
+            "status": "skipped",
+            "reason": (
+                "no Garmin credentials available; run `hai auth garmin` "
+                "(or pass --with-auth) before --with-first-pull"
+            ),
+        }
+    if not db_path.exists():
+        return {
+            "status": "skipped",
+            "reason": f"state DB not found at {db_path}",
+        }
+    if days < 1:
+        return {
+            "status": "skipped",
+            "reason": f"invalid --first-pull-days: {days}",
+        }
+
+    today = datetime.now(timezone.utc).date()
+    # Oldest-first so the projection chain writes days in chronological
+    # order — aids debugging if a specific date blows up mid-backfill.
+    dates = [today - timedelta(days=i) for i in range(days)]
+    dates.reverse()
+
+    pull_args = argparse.Namespace(
+        live=True,
+        db_path=str(db_path),
+        user_id=user_id,
+    )
+
+    day_results: list[dict[str, Any]] = []
+    for d in dates:
+        sync_id = _open_sync_row(
+            db_path,
+            source="garmin_live",
+            user_id=user_id,
+            mode="live",
+            for_date=d,
+        )
+        try:
+            source_name, projected = _daily_pull_and_project(
+                pull_args, as_of=d, user_id=user_id, db_path=db_path,
+            )
+        except GarminLiveError as exc:
+            _close_sync_row_failed(db_path, sync_id, exc)
+            day_results.append({
+                "date": d.isoformat(),
+                "status": "failed",
+                "error_class": type(exc).__name__,
+                "error": str(exc),
+            })
+            continue
+        rows = 1 if projected else 0
+        _close_sync_row_ok(
+            db_path,
+            sync_id,
+            rows_pulled=rows,
+            rows_accepted=rows,
+            duplicates_skipped=0,
+            status="ok",
+        )
+        day_results.append({
+            "date": d.isoformat(),
+            "status": "ok",
+            "source": source_name,
+            "projected_raw_daily": bool(projected),
+        })
+
+    return {
+        "status": "ran",
+        "days_requested": days,
+        "days_succeeded": sum(1 for r in day_results if r["status"] == "ok"),
+        "days_failed": sum(1 for r in day_results if r["status"] == "failed"),
+        "per_day": day_results,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -3144,6 +3320,199 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     # initialised, creds missing, etc.) — maps to USER_INPUT per the
     # exit-code taxonomy ("state precondition the caller controls").
     return exit_codes.USER_INPUT if report.overall_status == "fail" else exit_codes.OK
+
+
+# ---------------------------------------------------------------------------
+# hai stats — local, read-only onboarding + engagement signal
+# ---------------------------------------------------------------------------
+
+
+def cmd_stats(args: argparse.Namespace) -> int:
+    """Summarise sync_run_log + runtime_event_log for the user's own DB.
+
+    Read-only. Three sections:
+
+      1. Sync freshness — last successful pull per source.
+      2. Recent command runs — last N rows from runtime_event_log.
+      3. Command + streak summary — counts per command, consecutive-day
+         streak for `hai daily` (UTC calendar dates).
+
+    Default output is human-readable text; pass ``--json`` for the
+    structured dict. Text stays stable enough for eyeballing; JSON is
+    the machine surface.
+
+    No telemetry leaves the device — this command reads local SQLite
+    only. The user can paste the JSON into a bug report; nothing here
+    is auto-sent anywhere.
+    """
+
+    from health_agent_infra.core.state import (
+        command_summary,
+        latest_successful_sync_per_source,
+        open_connection,
+        recent_events,
+        resolve_db_path,
+    )
+
+    db_path = resolve_db_path(args.db_path)
+    if not db_path.exists():
+        if getattr(args, "json", False):
+            _emit_json({
+                "db_path": str(db_path),
+                "status": "db_missing",
+                "hint": "run `hai init` to create the state DB",
+            })
+        else:
+            print(
+                f"hai stats: no state DB at {db_path}. "
+                f"Run `hai init` first.",
+                file=sys.stderr,
+            )
+        return exit_codes.USER_INPUT
+
+    user_id = getattr(args, "user_id", "u_local_1")
+    limit = max(1, int(getattr(args, "limit", 7) or 7))
+
+    conn = open_connection(db_path)
+    try:
+        freshness = latest_successful_sync_per_source(conn, user_id=user_id)
+        recent = recent_events(conn, limit=limit)
+        summary = command_summary(conn)
+        streak = _daily_streak_from_events(conn)
+    finally:
+        conn.close()
+
+    report: dict[str, Any] = {
+        "db_path": str(db_path),
+        "user_id": user_id,
+        "sync_freshness": {
+            source: {
+                "started_at": row.get("started_at"),
+                "completed_at": row.get("completed_at"),
+                "status": row.get("status"),
+                "for_date": row.get("for_date"),
+                "mode": row.get("mode"),
+            }
+            for source, row in freshness.items()
+        },
+        "recent_events": [
+            {
+                "event_id": r["event_id"],
+                "command": r["command"],
+                "started_at": r["started_at"],
+                "completed_at": r["completed_at"],
+                "status": r["status"],
+                "exit_code": r["exit_code"],
+                "duration_ms": r["duration_ms"],
+                "error_class": r["error_class"],
+                "error_message": r["error_message"],
+            }
+            for r in recent
+        ],
+        "command_summary": summary,
+        "daily_streak_days": streak,
+    }
+
+    if getattr(args, "json", False):
+        _emit_json(report)
+    else:
+        sys.stdout.write(_render_stats_text(report))
+    return exit_codes.OK
+
+
+def _daily_streak_from_events(conn: sqlite3.Connection) -> int:
+    """Consecutive UTC calendar days ending today with ≥1 successful `hai daily`.
+
+    Returns 0 if today doesn't have a successful run. The streak is
+    counted backward from today (inclusive) — missing any intervening
+    day breaks the chain. Robust to a pre-migration-012 DB: returns 0
+    rather than crashing.
+    """
+
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT substr(started_at, 1, 10) AS day "
+            "FROM runtime_event_log "
+            "WHERE command = 'daily' AND status = 'ok' "
+            "ORDER BY day DESC"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return 0
+
+    days_with_ok = {row["day"] for row in rows}
+    if not days_with_ok:
+        return 0
+
+    streak = 0
+    today = datetime.now(timezone.utc).date()
+    cursor = today
+    while cursor.isoformat() in days_with_ok:
+        streak += 1
+        cursor -= timedelta(days=1)
+    return streak
+
+
+def _render_stats_text(report: dict[str, Any]) -> str:
+    """Human-readable `hai stats` view. Stable enough for eyeballing."""
+
+    lines: list[str] = []
+    lines.append(f"hai stats  —  db: {report['db_path']}")
+    lines.append(f"             user: {report['user_id']}")
+    lines.append("")
+
+    # Sync freshness
+    lines.append("Sync freshness (last successful pull per source):")
+    fresh = report["sync_freshness"]
+    if not fresh:
+        lines.append("  (no successful syncs yet — run `hai pull --live` or `hai daily`)")
+    else:
+        for source in sorted(fresh):
+            row = fresh[source]
+            started = row.get("started_at") or "—"
+            for_date = row.get("for_date") or ""
+            suffix = f"  for {for_date}" if for_date else ""
+            lines.append(f"  {source:16s} {started}  {row.get('status'):<8s}{suffix}")
+    lines.append("")
+
+    # Recent events
+    lines.append(f"Recent runs (runtime_event_log, last {len(report['recent_events'])}):")
+    events = report["recent_events"]
+    if not events:
+        lines.append("  (no logged runs yet — `hai daily` starts recording once the DB exists)")
+    else:
+        for evt in events:
+            started = evt.get("started_at") or "—"
+            cmd = evt.get("command", "?")
+            status = evt.get("status", "?")
+            dur = evt.get("duration_ms")
+            dur_s = f"{dur} ms" if dur is not None else "—"
+            line = f"  {started}  {cmd:<8s} {status:<6s} {dur_s:>8s}"
+            if evt.get("error_class"):
+                line += f"   {evt['error_class']}: {evt.get('error_message', '')}"
+            lines.append(line)
+    lines.append("")
+
+    # Command summary + streak
+    lines.append("Command summary:")
+    summary = report["command_summary"]
+    if not summary:
+        lines.append("  (no commands logged yet)")
+    else:
+        for cmd in sorted(summary):
+            counts = summary[cmd]
+            lines.append(
+                f"  {cmd:<10s} ok: {counts.get('ok', 0):<4d} "
+                f"failed: {counts.get('failed', 0):<4d} "
+                f"total: {counts.get('total', 0)}"
+            )
+    lines.append("")
+
+    streak = report["daily_streak_days"]
+    streak_suffix = " (run `hai daily` today to start one)" if streak == 0 else ""
+    lines.append(f"Daily streak: {streak} day(s){streak_suffix}")
+    lines.append("")
+
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -4122,6 +4491,24 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.add_argument("--force", action="store_true",
                         help="Overwrite an existing thresholds TOML and "
                              "existing skills directories of the same name.")
+    p_init.add_argument("--with-auth", action="store_true",
+                        help="After the non-interactive setup, prompt for "
+                             "Garmin credentials and store them in the OS "
+                             "keyring (equivalent to running `hai auth "
+                             "garmin` afterward). Requires a TTY.")
+    p_init.add_argument("--with-first-pull", action="store_true",
+                        help="After setup (and --with-auth, if used), pull "
+                             "+ project the last N days of Garmin data via "
+                             "the live adapter so `hai daily` has history "
+                             "to reason over on day one. Requires Garmin "
+                             "credentials.")
+    p_init.add_argument("--first-pull-days", type=int, default=7,
+                        help="Number of days to backfill with "
+                             "--with-first-pull (default: 7). Ignored "
+                             "without --with-first-pull.")
+    p_init.add_argument("--user-id", default="u_local_1",
+                        help="User id to record against the backfill's "
+                             "sync_run_log rows (default: u_local_1).")
     p_init.set_defaults(func=cmd_init)
     annotate_contract(
         p_init,
@@ -4169,6 +4556,40 @@ def build_parser() -> argparse.ArgumentParser:
         description=(
             "Report runtime health: DB present, migrations up to date, "
             "per-source freshness, today's accepted counts."
+        ),
+    )
+
+    p_stats = sub.add_parser(
+        "stats",
+        help=(
+            "Summarise local sync + command-invocation history from the "
+            "state DB. Read-only, never leaves the device."
+        ),
+    )
+    p_stats.add_argument("--db-path", default=None,
+                         help="Override state DB path (default: "
+                              "$HAI_STATE_DB or platform default).")
+    p_stats.add_argument("--user-id", default="u_local_1",
+                         help="Whose sync freshness to report. "
+                              "Default: u_local_1.")
+    p_stats.add_argument("--limit", type=int, default=7,
+                         help="Number of recent runtime_event_log rows "
+                              "to include (default: 7).")
+    p_stats.add_argument("--json", action="store_true",
+                         help="Emit the structured report dict as JSON "
+                              "instead of the human-readable text view.")
+    p_stats.set_defaults(func=cmd_stats)
+    annotate_contract(
+        p_stats,
+        mutation="read-only",
+        idempotent="n/a",
+        json_output="opt-in",  # text default, JSON via flag
+        exit_codes=("OK", "USER_INPUT"),
+        agent_safe=True,
+        description=(
+            "Summarise sync_run_log (last pull per source) + "
+            "runtime_event_log (recent commands, daily streak) from the "
+            "user's local DB. No telemetry leaves the device."
         ),
     )
 

--- a/src/health_agent_infra/core/state/__init__.py
+++ b/src/health_agent_infra/core/state/__init__.py
@@ -59,17 +59,29 @@ from health_agent_infra.core.state.sync_log import (
     latest_successful_sync_per_source,
     sync_run,
 )
+from health_agent_infra.core.state.runtime_event_log import (
+    begin_event,
+    command_summary,
+    complete_event,
+    fail_event,
+    recent_events,
+    runtime_event,
+)
 
 __all__ = [
     "DEFAULT_DB_PATH",
     "ReprojectBaseDirError",
     "apply_pending_migrations",
     "available_domains",
+    "begin_event",
     "begin_sync",
     "build_snapshot",
+    "command_summary",
+    "complete_event",
     "complete_sync",
     "current_schema_version",
     "delete_canonical_plan_cascade",
+    "fail_event",
     "fail_sync",
     "initialize_database",
     "latest_nutrition_submission_id",
@@ -104,7 +116,9 @@ __all__ = [
     "read_canonical_plan",
     "read_domain",
     "read_proposals_for_plan_key",
+    "recent_events",
     "reproject_from_jsonl",
     "resolve_db_path",
+    "runtime_event",
     "sync_run",
 ]

--- a/src/health_agent_infra/core/state/migrations/012_runtime_event_log.sql
+++ b/src/health_agent_infra/core/state/migrations/012_runtime_event_log.sql
@@ -1,0 +1,52 @@
+-- Migration 012 — runtime_event_log.
+--
+-- Records one row per user-facing CLI command invocation (`hai daily`
+-- first; others opt in over time). Phase-A onboarding telemetry so a
+-- user can answer "did I actually run `hai daily` this week?" from
+-- their own local DB without any data leaving the device.
+--
+-- Distinct from sync_run_log (migration 008) on purpose:
+--   - sync_run_log scope = external data acquisition (pull / intake).
+--   - runtime_event_log scope = command invocations by the user/agent.
+--   A single `hai daily` run may write multiple sync_run_log rows (one
+--   per source-pull) but exactly one runtime_event_log row.
+--
+-- Row lifecycle parallels sync_run_log:
+--   1. begin_event inserts with started_at + status='failed' (pessimistic).
+--   2. On normal completion, complete_event stamps completed_at +
+--      final status + exit_code + duration_ms + optional context_json.
+--   3. On exception, fail_event stamps completed_at + error_class +
+--      error_message; status stays 'failed'.
+--
+-- status is 'ok' or 'failed' only — no 'partial'. A command either
+-- returned 0 ("ok") or did not ("failed"). The exit_code column carries
+-- the exact taxonomy token (OK=0, USER_INPUT=2, TRANSIENT=75, etc.)
+-- so downstream tools can distinguish soft failures (non-zero exit) from
+-- crashes (exception recorded in error_class).
+--
+-- context_json is an opaque payload the caller fills in — e.g. for
+-- `hai daily`, the overall_status + domain counts. Keeping it as
+-- free-form JSON avoids a migration every time a command wants to
+-- record a new field.
+--
+-- Index covers the two dominant read patterns:
+--   - "show me the last N `hai daily` runs" (hai stats)
+--   - "show me recent runs across all commands" (hai stats default)
+
+CREATE TABLE runtime_event_log (
+  event_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  command         TEXT NOT NULL,
+  user_id         TEXT,
+  started_at      TEXT NOT NULL,
+  completed_at    TEXT,
+  status          TEXT NOT NULL,
+  exit_code       INTEGER,
+  duration_ms     INTEGER,
+  error_class     TEXT,
+  error_message   TEXT,
+  context_json    TEXT,
+  CHECK (status IN ('ok', 'failed'))
+);
+
+CREATE INDEX idx_runtime_event_log_command_date
+  ON runtime_event_log(command, started_at DESC);

--- a/src/health_agent_infra/core/state/runtime_event_log.py
+++ b/src/health_agent_infra/core/state/runtime_event_log.py
@@ -1,0 +1,275 @@
+"""Runtime event bookkeeping — write + read helpers for ``runtime_event_log``.
+
+Mirror of :mod:`sync_log` scoped to CLI command invocations rather than
+external sync acquisitions. Three primitive functions (``begin_event`` /
+``complete_event`` / ``fail_event``) map 1:1 to the row lifecycle in
+migration 012; a context manager (:func:`runtime_event`) stitches them
+together and handles the common "open row, run body, close row" flow
+including best-effort fallback when the DB doesn't exist yet (e.g.
+before ``hai init`` has run).
+
+Readers (:func:`recent_events`, :func:`command_summary`) back the
+``hai stats`` view: they answer "did the user run `hai daily` this
+week?" and "what's the failure rate?" from local data the user owns.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Literal, Optional
+
+
+RuntimeStatus = Literal["ok", "failed"]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def begin_event(
+    conn: sqlite3.Connection,
+    *,
+    command: str,
+    user_id: Optional[str] = None,
+) -> int:
+    """Open a new runtime event row; return its ``event_id``.
+
+    Inserted with ``status='failed'`` — a crash between this call and a
+    later completion leaves the row truthfully reflecting "we started
+    and never confirmed." Finalised by a later :func:`complete_event`
+    or :func:`fail_event`.
+    """
+
+    cursor = conn.execute(
+        "INSERT INTO runtime_event_log "
+        "(command, user_id, started_at, status) "
+        "VALUES (?, ?, ?, 'failed')",
+        (command, user_id, _now_iso()),
+    )
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+def complete_event(
+    conn: sqlite3.Connection,
+    event_id: int,
+    *,
+    status: RuntimeStatus,
+    exit_code: Optional[int] = None,
+    duration_ms: Optional[int] = None,
+    context: Optional[dict[str, Any]] = None,
+) -> None:
+    """Stamp completion metadata + final status on an open runtime event.
+
+    ``status`` is either 'ok' or 'failed'. Callers with an exception
+    should use :func:`fail_event` instead so the error_class /
+    error_message columns get populated.
+    """
+
+    if status not in ("ok", "failed"):
+        raise ValueError(
+            f"complete_event: status must be 'ok' or 'failed'; got {status!r}"
+        )
+    conn.execute(
+        "UPDATE runtime_event_log SET "
+        "  completed_at = ?, status = ?, "
+        "  exit_code = ?, duration_ms = ?, context_json = ? "
+        "WHERE event_id = ?",
+        (
+            _now_iso(),
+            status,
+            exit_code,
+            duration_ms,
+            json.dumps(context) if context is not None else None,
+            event_id,
+        ),
+    )
+    conn.commit()
+
+
+def fail_event(
+    conn: sqlite3.Connection,
+    event_id: int,
+    *,
+    error_class: str,
+    error_message: str,
+    exit_code: Optional[int] = None,
+    duration_ms: Optional[int] = None,
+    context: Optional[dict[str, Any]] = None,
+) -> None:
+    """Stamp completion + exception metadata; status stays 'failed'."""
+
+    conn.execute(
+        "UPDATE runtime_event_log SET "
+        "  completed_at = ?, status = 'failed', "
+        "  exit_code = ?, duration_ms = ?, "
+        "  error_class = ?, error_message = ?, context_json = ? "
+        "WHERE event_id = ?",
+        (
+            _now_iso(),
+            exit_code,
+            duration_ms,
+            error_class,
+            error_message,
+            json.dumps(context) if context is not None else None,
+            event_id,
+        ),
+    )
+    conn.commit()
+
+
+@contextmanager
+def runtime_event(
+    db_path: Optional[Path],
+    *,
+    command: str,
+    user_id: Optional[str] = None,
+) -> Iterator[dict[str, Any]]:
+    """Context manager wrapping begin/complete/fail.
+
+    Best-effort: a missing DB file or a pre-migration-012 schema turns
+    the block into a no-op so commands that run before state init (or
+    against an old DB) still function. The caller fills the yielded dict
+    to influence the finalisation:
+
+        with runtime_event(db_path, command="daily", user_id=u) as evt:
+            rc = _do_the_work()
+            evt["exit_code"] = rc
+            evt["context"] = {"overall_status": "complete"}
+
+    On normal exit, status is derived from ``exit_code`` (0 → 'ok', else
+    'failed') unless the caller overrides ``evt["status"]``. On
+    exception, :func:`fail_event` is called with the exception's class
+    and message; the exception then re-raises.
+    """
+
+    if db_path is None or not Path(db_path).exists():
+        # DB doesn't exist — e.g. pre-init. Yield a harmless dict so the
+        # body still runs; logging is just silently skipped.
+        yield {"event_id": None, "exit_code": None, "context": None, "status": None}
+        return
+
+    # Local imports keep this module's test surface free of circular
+    # dependencies on the broader state package.
+    from health_agent_infra.core.state.store import open_connection
+
+    try:
+        conn = open_connection(Path(db_path))
+    except sqlite3.Error:
+        yield {"event_id": None, "exit_code": None, "context": None, "status": None}
+        return
+
+    try:
+        try:
+            event_id = begin_event(conn, command=command, user_id=user_id)
+        except sqlite3.OperationalError:
+            # Pre-migration-012 DB: silently skip logging.
+            yield {"event_id": None, "exit_code": None, "context": None, "status": None}
+            return
+
+        started_dt = datetime.now(timezone.utc)
+        ctx: dict[str, Any] = {
+            "event_id": event_id,
+            "exit_code": None,
+            "context": None,
+            "status": None,
+        }
+        try:
+            yield ctx
+        except Exception as exc:
+            duration_ms = _elapsed_ms(started_dt)
+            fail_event(
+                conn,
+                event_id,
+                error_class=type(exc).__name__,
+                error_message=str(exc),
+                exit_code=ctx.get("exit_code"),
+                duration_ms=duration_ms,
+                context=ctx.get("context"),
+            )
+            raise
+        else:
+            duration_ms = _elapsed_ms(started_dt)
+            # Explicit override wins; otherwise derive from exit_code.
+            explicit_status = ctx.get("status")
+            if explicit_status in ("ok", "failed"):
+                final_status: RuntimeStatus = explicit_status  # type: ignore[assignment]
+            else:
+                exit_code = ctx.get("exit_code")
+                final_status = "ok" if exit_code == 0 else "failed"
+            complete_event(
+                conn,
+                event_id,
+                status=final_status,
+                exit_code=ctx.get("exit_code"),
+                duration_ms=duration_ms,
+                context=ctx.get("context"),
+            )
+    finally:
+        conn.close()
+
+
+def _elapsed_ms(started_dt: datetime) -> int:
+    return int((datetime.now(timezone.utc) - started_dt).total_seconds() * 1000)
+
+
+def recent_events(
+    conn: sqlite3.Connection,
+    *,
+    command: Optional[str] = None,
+    limit: int = 7,
+) -> list[dict[str, Any]]:
+    """Return the most recent runtime events (optionally filtered by command).
+
+    Ordered newest → oldest. Robust to a DB that predates migration 012:
+    returns an empty list so downstream rendering stays alive.
+    """
+
+    try:
+        if command is not None:
+            rows = conn.execute(
+                "SELECT * FROM runtime_event_log "
+                "WHERE command = ? "
+                "ORDER BY started_at DESC LIMIT ?",
+                (command, limit),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM runtime_event_log "
+                "ORDER BY started_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+    except sqlite3.OperationalError:
+        return []
+    return [dict(row) for row in rows]
+
+
+def command_summary(conn: sqlite3.Connection) -> dict[str, dict[str, int]]:
+    """Aggregate counts per (command, status).
+
+    Returns a dict shaped ``{command: {"ok": N, "failed": M, "total": N+M}}``.
+    Empty dict when the table is missing.
+    """
+
+    try:
+        rows = conn.execute(
+            "SELECT command, status, COUNT(*) AS n "
+            "FROM runtime_event_log "
+            "GROUP BY command, status"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return {}
+
+    summary: dict[str, dict[str, int]] = {}
+    for row in rows:
+        command = row["command"]
+        status = row["status"]
+        n = int(row["n"])
+        bucket = summary.setdefault(command, {"ok": 0, "failed": 0, "total": 0})
+        bucket[status] = n
+        bucket["total"] += n
+    return summary


### PR DESCRIPTION
## Summary
- **hai init** gains `--with-auth` (interactive Garmin credential capture) and `--with-first-pull` (N-day live backfill via the existing live adapter, default 7, override via `--first-pull-days`). Default path stays non-interactive and agent-safe; the new flags explicitly opt in to the interactive surface.
- **Migration 012** adds `runtime_event_log` mirroring `sync_run_log`'s lifecycle. `core/state/runtime_event_log.py` ships `begin/complete/fail` primitives plus a context manager that gracefully no-ops against a missing or pre-migration DB. `cmd_daily` wraps itself with the context manager so every invocation writes one row.
- **hai stats** (new, read-only, agent-safe) reads `sync_run_log` + `runtime_event_log` to summarise sync freshness, recent command runs, and the consecutive-day streak. No telemetry leaves the device.
- **README** rewritten: new positioning line, new install block using the new init flags, reading list moved below the fold. Launch artifacts (screencast shot list, Show HN draft, PyPI publish checklist) land in `reporting/docs/launch/`.
- **Version** bumped to `0.1.1`. **1489 tests pass** (+26 new), 2 skipped (pre-existing).

## Already live
`health-agent-infra 0.1.1` is already published to real PyPI as of the session that produced this branch:
- https://pypi.org/project/health-agent-infra/0.1.1/
- `pip install health-agent-infra` now pulls the full Phase A surface.

Merging this PR just syncs `main` with what's already on PyPI.

## Merge strategy
**Use "Create a merge commit" or "Rebase and merge" — not "Squash and merge."** A squash creates a new sha, which would mis-align the locally-prepared `v0.1.1` tag. After this merges I'll tag the merged commit and push the tag.

## Follow-up
A separate tiny PR will bump `pyproject.toml` to `0.1.2.dev0` on `main` so local installs don't silently shadow the published `0.1.1`.

## Test plan
- [x] `python3 -m pytest safety/tests/` → 1489 passed, 2 skipped.
- [x] Fresh venv install from real PyPI: `hai --version` → `hai 0.1.1`; `hai stats --help` registers.
- [x] `twine check dist/*` → PASSED (both sdist + wheel).
- [x] Dom dogfoods `hai init --with-auth --with-first-pull` on his real Garmin account (first unpreprod touch of that code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)