### PR TITLE
Bump to 0.1.2.dev0 post-v0.1.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "health_agent_infra"
-version = "0.1.1"
+version = "0.1.2.dev0"
 description = "Governed runtime + skills for a multi-domain personal health agent (recovery, running, sleep, stress, strength, nutrition)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/reporting/docs/agent_cli_contract.md
+++ b/reporting/docs/agent_cli_contract.md
@@ -47,7 +47,7 @@ forward-compatibility but is not currently emitted.
 
 ## Commands
 
-*37 commands; hai 0.1.1; schema agent_cli_contract.v1*
+*37 commands; hai 0.1.2.dev0; schema agent_cli_contract.v1*
 
 | Command | Mutation | Idempotent | JSON | Agent-safe | Exit codes | Description |
 |---|---|---|---|---|---|---|


### PR DESCRIPTION
## Summary
- `pyproject.toml` version `0.1.1` → `0.1.2.dev0`. Avoids local editable installs silently shadowing the published `0.1.1` — per PEP 440 the `.dev0` suffix sorts strictly below any `0.1.2` release and strictly above `0.1.1`, so `pipx install health-agent-infra` pulls the published `0.1.1` unless `-e .` is explicitly used.
- Regenerated `reporting/docs/agent_cli_contract.md` so the manifest header reads `hai 0.1.2.dev0` (matches what CI's freshly-installed package will produce). Without this the `test_committed_contract_doc_matches_generated` test would fail CI.

## Test plan
- [x] `python3 -m pytest safety/tests/test_capabilities.py` → 17 passed.
- [ ] CI (3.11 + 3.12) goes green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)