### PR TITLE
v0.1.2: fix hidden --with-auth prompt + replace backfill loop with single pull

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "health_agent_infra"
-version = "0.1.1"
+version = "0.1.2"
 description = "Governed runtime + skills for a multi-domain personal health agent (recovery, running, sleep, stress, strength, nutrition)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/reporting/docs/agent_cli_contract.md
+++ b/reporting/docs/agent_cli_contract.md
@@ -47,7 +47,7 @@ forward-compatibility but is not currently emitted.
 
 ## Commands
 
-*37 commands; hai 0.1.1; schema agent_cli_contract.v1*
+*37 commands; hai 0.1.2; schema agent_cli_contract.v1*
 
 | Command | Mutation | Idempotent | JSON | Agent-safe | Exit codes | Description |
 |---|---|---|---|---|---|---|

--- a/safety/tests/test_cli_init_doctor.py
+++ b/safety/tests/test_cli_init_doctor.py
@@ -427,25 +427,25 @@ def test_init_with_auth_prompts_and_stores(
     tmp_path, capsys, monkeypatch, fake_empty_store,
 ):
     # Simulate a user typing an email at input() and a password at getpass().
+    # 0.1.2 wiring: the email prompt is written to stderr *outside* of
+    # input() so the redirect_stdout around cmd_auth_garmin doesn't eat
+    # it. getpass already writes to stderr by default.
     import builtins
     import getpass as getpass_mod
 
-    prompts_seen: list[str] = []
-
-    def fake_input(prompt: str = "") -> str:
-        prompts_seen.append(prompt)
-        return "new_user@example.com"
+    getpass_prompts: list[str] = []
 
     def fake_getpass(prompt: str = "") -> str:
-        prompts_seen.append(prompt)
+        getpass_prompts.append(prompt)
         return "s3cret!"
 
-    monkeypatch.setattr(builtins, "input", fake_input)
+    monkeypatch.setattr(builtins, "input", lambda _="": "new_user@example.com")
     monkeypatch.setattr(getpass_mod, "getpass", fake_getpass)
 
     rc = cli_main(_init_argv(tmp_path, "--with-auth"))
     assert rc == 0
-    report = _stdout_json(capsys)
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
 
     assert report["steps"]["interactive_auth"]["status"] == "configured"
     # Credentials actually landed in the injected keyring.
@@ -453,9 +453,10 @@ def test_init_with_auth_prompts_and_stores(
     assert creds is not None
     assert creds.email == "new_user@example.com"
     assert creds.password == "s3cret!"
-    # Both prompts fired — proof we actually hit the interactive path.
-    assert any("email" in p.lower() for p in prompts_seen)
-    assert any("password" in p.lower() for p in prompts_seen)
+    # Email prompt went to stderr (the whole point of the 0.1.2 fix).
+    assert "Garmin email:" in captured.err
+    # Getpass prompt arg mentions password (getpass writes to stderr on its own).
+    assert any("password" in p.lower() for p in getpass_prompts)
 
 
 def test_init_with_auth_emits_single_json_document(
@@ -512,12 +513,25 @@ def test_init_with_first_pull_skips_without_credentials(
     assert "credentials" in first["reason"].lower()
 
 
-def test_init_with_first_pull_runs_default_seven_days(
+def test_init_with_first_pull_makes_single_adapter_call(
     tmp_path, capsys, monkeypatch, fake_stored_store,
 ):
-    # Inject a fake live adapter so no network / real Garmin call happens.
+    """0.1.2 design: one adapter.load(today), not a per-day loop."""
+
+    call_log: list = []
+
+    class _CountingAdapter:
+        source_name = "garmin_live"
+
+        def load(self, as_of):
+            call_log.append(as_of)
+            return {
+                "sleep": None, "resting_hr": [], "hrv": [],
+                "training_load": [], "raw_daily_row": None,
+            }
+
     monkeypatch.setattr(
-        cli_mod, "_build_live_adapter", lambda args: _NoRawRowAdapter(),
+        cli_mod, "_build_live_adapter", lambda args: _CountingAdapter(),
     )
 
     rc = cli_main(_init_argv(tmp_path, "--with-first-pull"))
@@ -525,49 +539,46 @@ def test_init_with_first_pull_runs_default_seven_days(
     report = _stdout_json(capsys)
 
     first = report["steps"]["first_pull"]
-    assert first["status"] == "ran"
-    assert first["days_requested"] == 7
-    assert first["days_succeeded"] == 7
-    assert first["days_failed"] == 0
-    assert len(first["per_day"]) == 7
-    # Dates are unique and chronological (oldest → newest).
-    dates_seen = [entry["date"] for entry in first["per_day"]]
-    assert dates_seen == sorted(dates_seen)
-    assert len(set(dates_seen)) == 7
-    # Every entry reports the source name and no projection (no raw_daily_row).
-    for entry in first["per_day"]:
-        assert entry["status"] == "ok"
-        assert entry["source"] == "garmin_live"
-        assert entry["projected_raw_daily"] is False
+    assert first["status"] == "ok"
+    assert first["history_days"] == 1  # default
+    assert first["approx_api_calls"] == 5  # 5 calls per fetch_day × 1 day
+    assert first["source"] == "garmin_live"
+
+    # Exactly one adapter.load(), and for today.
+    assert len(call_log) == 1
 
 
-def test_init_with_first_pull_respects_days_override(
+def test_init_with_first_pull_respects_history_days_override(
     tmp_path, capsys, monkeypatch, fake_stored_store,
 ):
     monkeypatch.setattr(
         cli_mod, "_build_live_adapter", lambda args: _NoRawRowAdapter(),
     )
 
-    rc = cli_main(_init_argv(tmp_path, "--with-first-pull", "--first-pull-days", "3"))
+    rc = cli_main(_init_argv(
+        tmp_path, "--with-first-pull", "--history-days", "7",
+    ))
     assert rc == 0
     report = _stdout_json(capsys)
 
     first = report["steps"]["first_pull"]
-    assert first["days_requested"] == 3
-    assert first["days_succeeded"] == 3
-    assert len(first["per_day"]) == 3
+    assert first["status"] == "ok"
+    assert first["history_days"] == 7
+    assert first["approx_api_calls"] == 35  # 5 × 7
 
 
-def test_init_with_first_pull_writes_one_sync_row_per_day(
+def test_init_with_first_pull_writes_one_sync_row(
     tmp_path, capsys, monkeypatch, fake_stored_store,
 ):
+    """Single pull → single sync_run_log row, status='ok'."""
+
     from health_agent_infra.core.state import open_connection
 
     monkeypatch.setattr(
         cli_mod, "_build_live_adapter", lambda args: _NoRawRowAdapter(),
     )
 
-    rc = cli_main(_init_argv(tmp_path, "--with-first-pull", "--first-pull-days", "4"))
+    rc = cli_main(_init_argv(tmp_path, "--with-first-pull"))
     assert rc == 0
 
     conn = open_connection(tmp_path / "state.db")
@@ -579,58 +590,52 @@ def test_init_with_first_pull_writes_one_sync_row_per_day(
     finally:
         conn.close()
 
-    # Four successful live-pull rows, one per backfill day.
-    assert len(rows) == 4
-    assert all(row["source"] == "garmin_live" for row in rows)
-    assert all(row["status"] == "ok" for row in rows)
-    assert all(row["mode"] == "live" for row in rows)
-    # for_date values cover a chronological 4-day window with no gaps.
-    for_dates = sorted(row["for_date"] for row in rows)
-    assert len(set(for_dates)) == 4
+    assert len(rows) == 1
+    assert rows[0]["source"] == "garmin_live"
+    assert rows[0]["status"] == "ok"
+    assert rows[0]["mode"] == "live"
 
 
-def test_init_with_first_pull_continues_past_per_day_failure(
+def test_init_with_first_pull_records_failure_with_hint(
     tmp_path, capsys, monkeypatch, fake_stored_store,
 ):
-    from health_agent_infra.core.pull.garmin_live import GarminLiveError
+    """A GarminLiveError (e.g. 429) is surfaced with a retry hint."""
 
-    class _SometimesFailingAdapter:
+    from health_agent_infra.core.pull.garmin_live import GarminLiveError
+    from health_agent_infra.core.state import open_connection
+
+    class _ExplodingAdapter:
         source_name = "garmin_live"
 
-        def __init__(self):
-            self._call_count = 0
-
         def load(self, as_of):
-            self._call_count += 1
-            # Fail on the 2nd call so we can prove the loop doesn't abort.
-            if self._call_count == 2:
-                raise GarminLiveError("simulated 503 on day 2")
-            return {
-                "sleep": None,
-                "resting_hr": [],
-                "hrv": [],
-                "training_load": [],
-                "raw_daily_row": None,
-            }
+            raise GarminLiveError("429 Too Many Requests")
 
-    # Reuse one adapter instance across the backfill so call_count survives.
-    adapter = _SometimesFailingAdapter()
-    monkeypatch.setattr(cli_mod, "_build_live_adapter", lambda args: adapter)
+    monkeypatch.setattr(
+        cli_mod, "_build_live_adapter", lambda args: _ExplodingAdapter(),
+    )
 
-    rc = cli_main(_init_argv(tmp_path, "--with-first-pull", "--first-pull-days", "5"))
+    rc = cli_main(_init_argv(tmp_path, "--with-first-pull"))
+    # Init itself doesn't fail — first_pull is advisory, not required.
     assert rc == 0
     report = _stdout_json(capsys)
 
     first = report["steps"]["first_pull"]
-    assert first["status"] == "ran"
-    assert first["days_requested"] == 5
-    assert first["days_succeeded"] == 4
-    assert first["days_failed"] == 1
-    # The failure entry carries error context for later triage.
-    failed_entries = [e for e in first["per_day"] if e["status"] == "failed"]
-    assert len(failed_entries) == 1
-    assert failed_entries[0]["error_class"] == "GarminLiveError"
-    assert "503" in failed_entries[0]["error"]
+    assert first["status"] == "failed"
+    assert first["error_class"] == "GarminLiveError"
+    assert "429" in first["error"]
+    # The hint guides the user to a lower-footprint retry.
+    assert "history-days 1" in first["hint"]
+    # Failed sync row is still persisted for the audit trail.
+    conn = open_connection(tmp_path / "state.db")
+    try:
+        rows = conn.execute(
+            "SELECT status, error_class FROM sync_run_log"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0]["status"] == "failed"
+    assert rows[0]["error_class"] == "GarminLiveError"
 
 
 def test_init_with_auth_and_first_pull_end_to_end(
@@ -648,7 +653,7 @@ def test_init_with_auth_and_first_pull_end_to_end(
     )
 
     rc = cli_main(_init_argv(
-        tmp_path, "--with-auth", "--with-first-pull", "--first-pull-days", "2",
+        tmp_path, "--with-auth", "--with-first-pull", "--history-days", "2",
     ))
     assert rc == 0
     report = _stdout_json(capsys)
@@ -657,11 +662,11 @@ def test_init_with_auth_and_first_pull_end_to_end(
     assert report["steps"]["auth_garmin"]["status"] == "missing"  # pre-prompt snapshot
     assert report["steps"]["interactive_auth"]["status"] == "configured"
 
-    # Step 6: first-pull honoured the freshly-stored creds.
+    # Step 6: first-pull honoured the freshly-stored creds with the chosen window.
     first = report["steps"]["first_pull"]
-    assert first["status"] == "ran"
-    assert first["days_requested"] == 2
-    assert first["days_succeeded"] == 2
+    assert first["status"] == "ok"
+    assert first["history_days"] == 2
+    assert first["approx_api_calls"] == 10
 
 
 def test_init_without_new_flags_does_not_add_new_steps(

--- a/src/health_agent_infra/cli.py
+++ b/src/health_agent_infra/cli.py
@@ -3101,9 +3101,10 @@ def cmd_init(args: argparse.Namespace) -> int:
             args, already_configured=configured,
         )
 
-    # 6. optional: first-pull backfill via the live adapter. Runs the same
-    # pull + project path `hai daily` uses, N days ending today, one
-    # sync_run_log row per day so freshness + audit stay consistent.
+    # 6. optional: first-pull today via the live adapter. One adapter call
+    # (not a loop), `history_days`-wide window (default 1 → 5 API calls).
+    # See _run_first_pull_backfill's docstring for why the 0.1.1 loop was
+    # replaced.
     if getattr(args, "with_first_pull", False):
         # Re-check credentials: step 5 may have just populated them.
         store_now = _credential_store_for(args)
@@ -3112,7 +3113,7 @@ def cmd_init(args: argparse.Namespace) -> int:
             args,
             db_path=resolved,
             user_id=getattr(args, "user_id", "u_local_1"),
-            days=int(getattr(args, "first_pull_days", 7) or 7),
+            history_days=int(getattr(args, "history_days", 1) or 1),
             credentials_available=creds_now,
         )
 
@@ -3123,33 +3124,66 @@ def cmd_init(args: argparse.Namespace) -> int:
 def _run_interactive_auth(
     args: argparse.Namespace, *, already_configured: bool,
 ) -> dict[str, Any]:
-    """Run ``cmd_auth_garmin`` interactively; record outcome only.
+    """Prompt for Garmin credentials; hand them to ``cmd_auth_garmin``.
 
-    Silences cmd_auth_garmin's own JSON stdout so ``hai init`` emits a
-    single consolidated report. stderr passes through so typos still
-    surface. No-op if credentials are already present.
+    Prompts are written by this wrapper (to stderr) rather than by
+    ``cmd_auth_garmin``'s own ``input()`` / ``getpass()``. Reason: we
+    redirect ``cmd_auth_garmin``'s stdout to suppress its JSON emission
+    (so ``hai init`` stays a single-document stream), and Python's
+    ``input()`` writes its prompt to stdout — which would get swallowed
+    by the same redirect, leaving the user staring at a blank cursor.
+    Routing prompts to stderr keeps them visible and leaves stdout
+    unambiguous.
+
+    The collected email + password are passed to ``cmd_auth_garmin`` via
+    ``--email`` and ``--password-env`` so no further prompting happens
+    downstream; the env var is scrubbed on exit.
+
+    No-op if credentials are already present.
     """
 
     if already_configured:
         return {"status": "already_configured"}
 
+    import getpass as _getpass
     import io
+    import os as _os
     from contextlib import redirect_stdout
 
-    auth_args = argparse.Namespace(
-        email=None,
-        password_stdin=False,
-        password_env=None,
-        _credential_store_override=getattr(args, "_credential_store_override", None),
-    )
-    buf = io.StringIO()
-    with redirect_stdout(buf):
-        rc = cmd_auth_garmin(auth_args)
+    sys.stderr.write("Garmin email: ")
+    sys.stderr.flush()
+    try:
+        email = input().strip()
+    except EOFError:
+        return {"status": "user_skipped", "reason": "no input (EOF on email)"}
+    if not email:
+        return {"status": "user_skipped", "reason": "empty email"}
+    try:
+        password = _getpass.getpass("Garmin password: ")
+    except EOFError:
+        return {"status": "user_skipped", "reason": "no input (EOF on password)"}
+    if not password:
+        return {"status": "user_skipped", "reason": "empty password"}
+
+    env_name = "_HAI_INIT_WITH_AUTH_PW"
+    _os.environ[env_name] = password
+    try:
+        auth_args = argparse.Namespace(
+            email=email,
+            password_stdin=False,
+            password_env=env_name,
+            _credential_store_override=getattr(
+                args, "_credential_store_override", None,
+            ),
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cmd_auth_garmin(auth_args)
+    finally:
+        _os.environ.pop(env_name, None)
+
     if rc == exit_codes.OK:
         return {"status": "configured"}
-    # cmd_auth_garmin maps empty/EOF input to USER_INPUT. In the interactive
-    # `hai init --with-auth` context that's always "user walked away";
-    # other non-OK codes are a real failure worth flagging distinctly.
     if rc == exit_codes.USER_INPUT:
         return {"status": "user_skipped", "exit_code": int(rc)}
     return {"status": "failed", "exit_code": int(rc)}
@@ -3160,15 +3194,25 @@ def _run_first_pull_backfill(
     *,
     db_path: Path,
     user_id: str,
-    days: int,
+    history_days: int,
     credentials_available: bool,
 ) -> dict[str, Any]:
-    """Pull + project N days via the live adapter, one sync row per day.
+    """Pull + project today's state via a single live-adapter call.
 
-    Per-day failures are recorded and the loop continues — a transient
-    Garmin 5xx on day 3 shouldn't wipe out days 4–7 of backfill. Total
-    counts are summarised in the returned dict so the outer init report
-    stays scannable.
+    **Why one call, not a loop.** Each ``fetch_day`` makes ~5 Garmin
+    API requests, and the adapter internally fetches a `history_days`
+    window of days. So one ``adapter.load(today)`` with
+    `history_days=1` = 5 requests; with the default `history_days=14`
+    it's 70 requests. A multi-day backfill loop calling ``adapter.load``
+    N times (the 0.1.1 design) produced N*5*14 requests — hundreds in a
+    burst — which reliably triggered Garmin's rate limiter and left
+    many users unable to complete setup.
+
+    The replacement: one call, small default history window, explicit
+    opt-in for larger. The historical-series arrays (resting_hr, hrv,
+    training_load) come from the same call's history window, so wider
+    windows still surface baseline context when the user wants it —
+    they just incur a bigger burst.
     """
 
     if not credentials_available:
@@ -3184,68 +3228,68 @@ def _run_first_pull_backfill(
             "status": "skipped",
             "reason": f"state DB not found at {db_path}",
         }
-    if days < 1:
+    if history_days < 1:
         return {
             "status": "skipped",
-            "reason": f"invalid --first-pull-days: {days}",
+            "reason": f"invalid --history-days: {history_days}",
         }
 
     today = datetime.now(timezone.utc).date()
-    # Oldest-first so the projection chain writes days in chronological
-    # order — aids debugging if a specific date blows up mid-backfill.
-    dates = [today - timedelta(days=i) for i in range(days)]
-    dates.reverse()
 
+    # _daily_pull_and_project reads args.history_days when building the
+    # live adapter, so routing the config through that attribute is how
+    # the history window reaches the adapter without broadening the
+    # helper's signature.
     pull_args = argparse.Namespace(
         live=True,
         db_path=str(db_path),
         user_id=user_id,
+        history_days=history_days,
     )
 
-    day_results: list[dict[str, Any]] = []
-    for d in dates:
-        sync_id = _open_sync_row(
-            db_path,
-            source="garmin_live",
-            user_id=user_id,
-            mode="live",
-            for_date=d,
+    sync_id = _open_sync_row(
+        db_path,
+        source="garmin_live",
+        user_id=user_id,
+        mode="live",
+        for_date=today,
+    )
+    try:
+        source_name, projected = _daily_pull_and_project(
+            pull_args, as_of=today, user_id=user_id, db_path=db_path,
         )
-        try:
-            source_name, projected = _daily_pull_and_project(
-                pull_args, as_of=d, user_id=user_id, db_path=db_path,
-            )
-        except GarminLiveError as exc:
-            _close_sync_row_failed(db_path, sync_id, exc)
-            day_results.append({
-                "date": d.isoformat(),
-                "status": "failed",
-                "error_class": type(exc).__name__,
-                "error": str(exc),
-            })
-            continue
-        rows = 1 if projected else 0
-        _close_sync_row_ok(
-            db_path,
-            sync_id,
-            rows_pulled=rows,
-            rows_accepted=rows,
-            duplicates_skipped=0,
-            status="ok",
-        )
-        day_results.append({
-            "date": d.isoformat(),
-            "status": "ok",
-            "source": source_name,
-            "projected_raw_daily": bool(projected),
-        })
+    except GarminLiveError as exc:
+        _close_sync_row_failed(db_path, sync_id, exc)
+        return {
+            "status": "failed",
+            "date": today.isoformat(),
+            "history_days": history_days,
+            "approx_api_calls": 5 * history_days,
+            "error_class": type(exc).__name__,
+            "error": str(exc),
+            "hint": (
+                "429 / rate-limit errors are common on Garmin's API. "
+                "Wait 30–60 minutes before retrying; consider "
+                "--history-days 1 (5 requests) to minimise burst size."
+            ),
+        }
 
+    rows = 1 if projected else 0
+    _close_sync_row_ok(
+        db_path,
+        sync_id,
+        rows_pulled=rows,
+        rows_accepted=rows,
+        duplicates_skipped=0,
+        status="ok",
+    )
     return {
-        "status": "ran",
-        "days_requested": days,
-        "days_succeeded": sum(1 for r in day_results if r["status"] == "ok"),
-        "days_failed": sum(1 for r in day_results if r["status"] == "failed"),
-        "per_day": day_results,
+        "status": "ok",
+        "date": today.isoformat(),
+        "history_days": history_days,
+        "approx_api_calls": 5 * history_days,
+        "source": source_name,
+        "projected_raw_daily": bool(projected),
     }
 
 
@@ -4497,14 +4541,17 @@ def build_parser() -> argparse.ArgumentParser:
                              "keyring (equivalent to running `hai auth "
                              "garmin` afterward). Requires a TTY.")
     p_init.add_argument("--with-first-pull", action="store_true",
-                        help="After setup (and --with-auth, if used), pull "
-                             "+ project the last N days of Garmin data via "
-                             "the live adapter so `hai daily` has history "
-                             "to reason over on day one. Requires Garmin "
-                             "credentials.")
-    p_init.add_argument("--first-pull-days", type=int, default=7,
-                        help="Number of days to backfill with "
-                             "--with-first-pull (default: 7). Ignored "
+                        help="After setup (and --with-auth, if used), do "
+                             "a single live-adapter pull for today so "
+                             "`hai daily` has state to reason over. One "
+                             "network call, configurable history window "
+                             "via --history-days. Requires Garmin creds.")
+    p_init.add_argument("--history-days", type=int, default=1,
+                        help="How many days of historical context the "
+                             "first-pull adapter fetches (default: 1 → "
+                             "~5 Garmin API calls). Larger windows give "
+                             "richer baselines but risk rate-limiting: "
+                             "each extra day adds ~5 API calls. Ignored "
                              "without --with-first-pull.")
     p_init.add_argument("--user-id", default="u_local_1",
                         help="User id to record against the backfill's "


### PR DESCRIPTION
## Two user-facing bugs from 0.1.1

Both were in `hai init --with-first-pull`, both hit Dom on his first real use.

### 1. `--with-auth` prompt was invisible
`_run_interactive_auth` redirected stdout around `cmd_auth_garmin` to suppress its JSON emission (so `hai init` remains a single-document stream). But Python's `input("Garmin email: ")` writes its prompt to stdout — which the redirect ate. The user saw a blank cursor, pressed Enter, and hit \"email must be non-empty.\"

**Fix:** prompt from the wrapper directly to stderr, pass the collected email + password to `cmd_auth_garmin` via `--email` + `--password-env` (scratch env var, scrubbed on exit). cmd_auth_garmin never re-prompts; the stdout redirect only catches its JSON.

### 2. `--with-first-pull` reliably rate-limited
Each `fetch_day` fires 5 Garmin API requests; each `adapter.load()` internally loops `fetch_day` over a 14-day history window = 70 requests per \"single day pull.\" The 0.1.1 backfill called `adapter.load()` N times (default 7) in a tight loop → **~490 requests in a burst**, with massive overlap (each day re-fetched the previous 13). Garmin 429'd reliably.

**Fix:** one `adapter.load(today)` call. `history_days` configurable via a new `--history-days` flag (default 1 → 5 API calls). Removed `--first-pull-days` — meaningless under the single-call design. The adapter's returned dict already carries the historical series for whatever window was requested, so wider windows still give richer baselines; they just incur a bigger single burst.

Failure path carries an explicit hint steering users toward `--history-days 1` after a 429.

## Summary of changes
- `src/health_agent_infra/cli.py` — rewrite `_run_interactive_auth` and `_run_first_pull_backfill`; update argparse (add `--history-days`, remove `--first-pull-days`).
- `safety/tests/test_cli_init_doctor.py` — rewrite the 6 first-pull tests against the new design; update the auth-prompt test to assert on stderr rather than `input()` prompt arg.
- `pyproject.toml` — `0.1.1` → `0.1.2`.
- `reporting/docs/agent_cli_contract.md` — regenerated (version + `hai init` help text).

## Test plan
- [x] `python3 -m pytest safety/tests/` → 1489 passed, 2 skipped.
- [x] `hai init --help` shows the new flags with correct descriptions.
- [ ] Dom retries `hai init --with-auth --with-first-pull` on his real Garmin account once the 429 cooldown clears.

## Follow-up
After merge: tag v0.1.2, rebuild dist artifacts, publish to PyPI, bump local to 0.1.3.dev0 in a small follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)